### PR TITLE
Harden webhook handling and manual payment exposure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 WebsiteBillingTesting
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,61 +1,44 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400"></a></p>
+# Website Billing Platform
 
-<p align="center">
-<a href="https://travis-ci.org/laravel/framework"><img src="https://travis-ci.org/laravel/framework.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/license.svg" alt="License"></a>
-</p>
+Website Billing Platform is a Laravel-based billing portal that provisions virtual servers, issues invoices, and integrates with multiple local payment gateways. The project now includes a guided first-time installation wizard, recurring billing automation, safer gateway handling, and customer self-service actions for managed services.
 
-## About Laravel
+## Key Features
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+- **Guided installation experience** – Complete migrations, create the initial administrator, and seed company branding from the `/install` wizard with environment validation.
+- **Recurring billing engine** – Automatically generates renewal invoices ahead of the service due date and suspends overdue services after the configured grace period.
+- **Config-aware payment gateways** – Only display and enable gateways that have valid credentials to prevent failed checkout attempts.
+- **Account credit wallet & ledger** – Track credit adjustments, apply balances to invoices with audit trails, and expose payment history with outstanding amounts to customers.
+- **Support ticket desk** – Clients can submit and reply to tickets, while admins manage queues, internal notes, and quick status actions from the dashboard.
+- **Security & operations dashboard** – Monitor revenue trends, pending invoices, login activity, open tickets, and renewal pipelines from the built-in admin overview.
+- **Admin client workspace** – Review client services, recent invoices, and credit history with one-click credit adjustments.
+- **Customer service controls** – Authenticated clients can reboot, power cycle, reset passwords, or open the remote console for their virtual machines.
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Getting Started
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+1. Ensure you are running **PHP 8.3** or newer and the required PHP extensions (OpenSSL, PDO, Mbstring, JSON, cURL) are enabled.
+2. Install dependencies:
+   ```bash
+   composer install
+   npm install && npm run dev
+   ```
+3. Configure your `.env` database connection and optional integrations (payment gateways, Virtfusion API keys, mail, etc.).
+4. Serve the application and open the installation wizard:
+   ```bash
+   php artisan serve
+   ```
+   Visit `http://localhost:8000/install` to run migrations, create the first administrator, and store company branding details. The wizard will mark `APP_INSTALLED=true` automatically.
 
-## Learning Laravel
+## Scheduled Tasks
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+The recurring billing automation is executed by the `billing:renewals` Artisan command. It is registered in the scheduler to run hourly, but you can adjust the frequency in `app/Console/Kernel.php`.
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains over 1500 video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+## Testing
 
-## Laravel Sponsors
-
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the Laravel [Patreon page](https://patreon.com/taylorotwell).
-
-### Premium Partners
-
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Cubet Techno Labs](https://cubettech.com)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[Many](https://www.many.co.uk)**
-- **[Webdock, Fast VPS Hosting](https://www.webdock.io/en)**
-- **[DevSquad](https://devsquad.com)**
-- **[OP.GG](https://op.gg)**
-
-## Contributing
-
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
-
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+Run the automated test suite with:
+```bash
+php artisan test
+```
 
 ## License
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+This project is open-sourced under the [MIT License](./LICENSE).

--- a/app/Console/Commands/GenerateRenewalInvoices.php
+++ b/app/Console/Commands/GenerateRenewalInvoices.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SuspendServiceJob;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\Service;
+use App\Support\Settings;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class GenerateRenewalInvoices extends Command
+{
+    protected $signature = 'billing:renewals';
+    protected $description = 'Generate renewal invoices and handle overdue services';
+
+    public function handle(): int
+    {
+        $now = Carbon::now();
+        $leadDays = (int) Settings::get('finance.renewal_lead_days', 5);
+        $graceDays = (int) Settings::get('finance.suspension_grace_days', 3);
+
+        $this->generateUpcomingInvoices($leadDays, $now);
+        $this->markOverdueInvoices($graceDays, $now);
+
+        return 0;
+    }
+
+    protected function generateUpcomingInvoices(int $leadDays, Carbon $now): void
+    {
+        $services = Service::with(['product', 'client'])
+            ->where('status', 'active')
+            ->whereNotNull('next_due_date')
+            ->whereDate('next_due_date', '<=', $now->copy()->addDays($leadDays))
+            ->get();
+
+        foreach ($services as $service) {
+            if (! $service->product || ! $service->client) {
+                continue;
+            }
+            $alreadyExists = InvoiceItem::where('service_id', $service->id)
+                ->whereHas('invoice', function ($query) use ($service) {
+                    $query->whereIn('status', ['unpaid', 'overdue'])
+                        ->whereDate('due_date', $service->next_due_date);
+                })
+                ->exists();
+            if ($alreadyExists) {
+                continue;
+            }
+
+            DB::transaction(function () use ($service) {
+                $product = $service->product;
+                $subtotal = round((float) $product->base_price, 2);
+                $taxRate = (float) Settings::get('finance.tax_rate', 0);
+                $taxTotal = $taxRate > 0 ? round($subtotal * ($taxRate / 100), 2) : 0.0;
+                $discount = 0.0;
+                $total = round($subtotal - $discount + $taxTotal, 2);
+
+                $invoice = Invoice::create([
+                    'client_id' => $service->client_id,
+                    'status' => 'unpaid',
+                    'subtotal' => $subtotal,
+                    'tax_total' => $taxTotal,
+                    'discount_total' => $discount,
+                    'tax_rate' => $taxRate,
+                    'total' => $total,
+                    'currency' => $product->currency,
+                    'due_date' => $service->next_due_date,
+                    'notes' => 'Renewal for service #'.$service->id,
+                ]);
+
+                InvoiceItem::create([
+                    'invoice_id' => $invoice->id,
+                    'product_id' => $product->id,
+                    'service_id' => $service->id,
+                    'description' => $product->name.' renewal ('.$service->billing_cycle.')',
+                    'quantity' => 1,
+                    'unit_price' => $subtotal,
+                    'discount' => $discount,
+                    'total' => $subtotal - $discount,
+                    'meta' => ['type' => 'renewal'],
+                ]);
+
+                $meta = $service->meta ?? [];
+                $meta['last_invoice_generated_at'] = Carbon::now()->toDateTimeString();
+                $meta['last_invoice_id'] = $invoice->id;
+                $service->meta = $meta;
+                $service->save();
+            });
+        }
+    }
+
+    protected function markOverdueInvoices(int $graceDays, Carbon $now): void
+    {
+        $invoices = Invoice::with(['items.service'])
+            ->whereIn('status', ['unpaid', 'overdue'])
+            ->whereNotNull('due_date')
+            ->whereDate('due_date', '<', $now->toDateString())
+            ->get();
+
+        foreach ($invoices as $invoice) {
+            $wasOverdue = $invoice->status === 'overdue';
+            if (! $wasOverdue) {
+                $invoice->status = 'overdue';
+                $invoice->save();
+            }
+            foreach ($invoice->items as $item) {
+                if (! $item->service) {
+                    continue;
+                }
+                $service = $item->service;
+                if (in_array($service->status, ['terminated', 'suspended'], true)) {
+                    continue;
+                }
+                $meta = $service->meta ?? [];
+                if (isset($meta['suspension_requested_at'])) {
+                    try {
+                        $requestedAt = Carbon::parse($meta['suspension_requested_at']);
+                        if ($requestedAt && $requestedAt->greaterThan($now->copy()->subHours(6))) {
+                            continue;
+                        }
+                    } catch (\Throwable $e) {
+                        // ignore parse errors and requeue suspension
+                    }
+                }
+                if ($graceDays <= 0) {
+                    SuspendServiceJob::dispatch($service->id);
+                    $meta['suspension_requested_at'] = $now->toDateTimeString();
+                    $service->meta = $meta;
+                    $service->save();
+                    continue;
+                }
+                $duePlusGrace = $invoice->due_date ? $invoice->due_date->copy()->addDays($graceDays) : null;
+                if ($duePlusGrace && $duePlusGrace->lte($now)) {
+                    SuspendServiceJob::dispatch($service->id);
+                    $meta['suspension_requested_at'] = $now->toDateTimeString();
+                    $service->meta = $meta;
+                    $service->save();
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\GenerateRenewalInvoices;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        GenerateRenewalInvoices::class,
     ];
 
     /**
@@ -24,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('billing:renewals')->hourly();
     }
 
     /**

--- a/app/Domain/Payments/Contracts/PaymentGateway.php
+++ b/app/Domain/Payments/Contracts/PaymentGateway.php
@@ -10,6 +10,7 @@ interface PaymentGateway
 {
     public function key(): string;
     public function displayName(): string;
+    public function isConfigured(): bool;
     public function createPayment(Invoice $invoice, array $options = []): Payment;
     public function handleWebhook(Request $request): void;
 }

--- a/app/Domain/Payments/Gateways/AbstractGateway.php
+++ b/app/Domain/Payments/Gateways/AbstractGateway.php
@@ -12,6 +12,7 @@ abstract class AbstractGateway implements PaymentGateway
 {
     abstract public function key(): string;
     abstract public function displayName(): string;
+    public function isConfigured(): bool { return true; }
     public function createPayment(Invoice $invoice, array $options = []): Payment { throw new RuntimeException('Not implemented'); }
     public function handleWebhook(Request $request): void { throw new RuntimeException('Not implemented'); }
 }

--- a/app/Domain/Payments/Gateways/DuitkuGateway.php
+++ b/app/Domain/Payments/Gateways/DuitkuGateway.php
@@ -15,6 +15,7 @@ class DuitkuGateway extends AbstractGateway implements PaymentGateway
 {
     public function key(): string { return 'duitku'; }
     public function displayName(): string { return 'Duitku'; }
+    public function isConfigured(): bool { return (bool) (config('duitku.merchant_code') && config('duitku.api_key')); }
     protected function isSandbox(): bool { return (bool) config('duitku.sandbox', true); }
     protected function baseUrl(): string { return $this->isSandbox()? 'https://api-sandbox.duitku.com':'https://api-prod.duitku.com'; }
     public function createPayment(Invoice $invoice, array $options = []): Payment

--- a/app/Domain/Payments/Gateways/MidtransGateway.php
+++ b/app/Domain/Payments/Gateways/MidtransGateway.php
@@ -15,6 +15,7 @@ class MidtransGateway extends AbstractGateway implements PaymentGateway
 {
     public function key(): string { return 'midtrans'; }
     public function displayName(): string { return 'Midtrans'; }
+    public function isConfigured(): bool { return (bool) (config('midtrans.server_key') && config('midtrans.client_key')); }
     protected function isSandbox(): bool { return (bool) config('midtrans.sandbox', true); }
     protected function snapUrl(): string { return $this->isSandbox()? 'https://app.sandbox.midtrans.com/snap/v1/transactions':'https://app.midtrans.com/snap/v1/transactions'; }
     protected function statusUrl(string $orderId): string { return $this->isSandbox()? "https://api.sandbox.midtrans.com/v2/{$orderId}/status":"https://api.midtrans.com/v2/{$orderId}/status"; }

--- a/app/Domain/Payments/Gateways/StripeGateway.php
+++ b/app/Domain/Payments/Gateways/StripeGateway.php
@@ -13,6 +13,7 @@ class StripeGateway extends AbstractGateway implements PaymentGateway
 {
     public function key(): string { return 'stripe'; }
     public function displayName(): string { return 'Stripe'; }
+    public function isConfigured(): bool { return (bool) (config('stripe.secret') && config('stripe.public')); }
     public function createPayment(Invoice $invoice, array $options = []): Payment
     {
         \Stripe\Stripe::setApiKey((string) config('stripe.secret'));

--- a/app/Domain/Payments/Gateways/TripayGateway.php
+++ b/app/Domain/Payments/Gateways/TripayGateway.php
@@ -15,6 +15,7 @@ class TripayGateway extends AbstractGateway implements PaymentGateway
 {
     public function key(): string { return 'tripay'; }
     public function displayName(): string { return 'Tripay'; }
+    public function isConfigured(): bool { return (bool) (config('tripay.api_key') && config('tripay.private_key') && config('tripay.merchant_code')); }
     protected function isSandbox(): bool { return (bool) config('tripay.sandbox', true); }
     protected function baseUrl(): string { return $this->isSandbox()? 'https://tripay.co.id/api-sandbox':'https://tripay.co.id/api'; }
 

--- a/app/Domain/Payments/Gateways/XenditGateway.php
+++ b/app/Domain/Payments/Gateways/XenditGateway.php
@@ -15,6 +15,7 @@ class XenditGateway extends AbstractGateway implements PaymentGateway
 {
     public function key(): string { return 'xendit'; }
     public function displayName(): string { return 'Xendit'; }
+    public function isConfigured(): bool { return (bool) (config('xendit.api_key') && config('xendit.callback_token')); }
     protected function apiKey(): string { return (string) config('xendit.api_key'); }
     public function createPayment(Invoice $invoice, array $options = []): Payment
     {

--- a/app/Http/Controllers/AdminClientController.php
+++ b/app/Http/Controllers/AdminClientController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use App\Support\CreditManager;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminClientController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified', 'admin']);
+    }
+
+    public function index(Request $request)
+    {
+        $search = $request->input('q');
+
+        $clients = Client::with('user')->withCount('services')
+            ->when($search, function ($query) use ($search) {
+                $query->where(function ($inner) use ($search) {
+                    $inner->where('company', 'like', "%{$search}%")
+                        ->orWhereHas('user', function ($q) use ($search) {
+                            $q->where('name', 'like', "%{$search}%")
+                              ->orWhere('email', 'like', "%{$search}%");
+                        });
+                });
+            })
+            ->orderByDesc('created_at')
+            ->paginate(20)
+            ->appends(['q' => $search]);
+
+        return view('admin.clients.index', compact('clients', 'search'));
+    }
+
+    public function show(Client $client)
+    {
+        $client->load([
+            'user',
+            'services.product',
+            'invoices' => function ($query) {
+                $query->orderByDesc('created_at')->limit(10);
+            },
+            'creditTransactions' => function ($query) {
+                $query->orderByDesc('created_at')->limit(10);
+            },
+        ]);
+
+        return view('admin.clients.show', [
+            'client' => $client,
+            'services' => $client->services,
+            'invoices' => $client->invoices,
+            'creditTransactions' => $client->creditTransactions,
+        ]);
+    }
+
+    public function adjustCredit(Request $request, Client $client)
+    {
+        $data = $request->validate([
+            'type' => 'required|in:credit,debit',
+            'amount' => 'required|numeric|min:0.01',
+            'description' => 'nullable|string|max:255',
+        ]);
+
+        if ($data['type'] === 'credit') {
+            CreditManager::addCredit($client, (float) $data['amount'], $data['description'] ?: 'Manual credit', Auth::id());
+        } else {
+            CreditManager::deductCredit($client, (float) $data['amount'], $data['description'] ?: 'Manual debit', Auth::id());
+        }
+
+        return redirect()->route('admin.clients.show', $client)->with('status', 'Client credit updated.');
+    }
+}

--- a/app/Http/Controllers/AdminDashboardController.php
+++ b/app/Http/Controllers/AdminDashboardController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Service;
+use App\Models\Ticket;
+use App\Models\LoginActivity;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+
+class AdminDashboardController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified', 'admin']);
+    }
+
+    public function index(): View
+    {
+        $now = Carbon::now();
+        $startOfMonth = $now->copy()->startOfMonth();
+        $lastSixMonths = $now->copy()->subMonths(5)->startOfMonth();
+
+        $stats = [
+            'total_clients' => Client::count(),
+            'new_clients_30_days' => Client::where('created_at', '>=', $now->copy()->subDays(30))->count(),
+            'active_services' => Service::where('status', 'active')->count(),
+            'pending_services' => Service::where('status', 'pending')->count(),
+            'suspended_services' => Service::where('status', 'suspended')->count(),
+            'revenue_month' => Invoice::where('status', 'paid')->where('paid_at', '>=', $startOfMonth)->sum('total'),
+            'revenue_30_days' => Invoice::where('status', 'paid')->where('paid_at', '>=', $now->copy()->subDays(30))->sum('total'),
+            'pending_invoices' => Invoice::whereIn('status', ['unpaid', 'overdue'])->count(),
+            'overdue_amount' => Invoice::where('status', 'overdue')->sum('total'),
+            'pending_manual_payments' => Payment::where('gateway', 'manual')->where('status', 'pending')->count(),
+            'open_tickets' => Ticket::where('status', '!=', 'closed')->count(),
+        ];
+
+        $revenueSeries = $this->revenueSeries($lastSixMonths, $now);
+        $upcomingRenewals = Service::with(['client.user', 'product'])
+            ->where('status', 'active')
+            ->whereNotNull('next_due_date')
+            ->orderBy('next_due_date')
+            ->limit(6)
+            ->get();
+
+        $recentInvoices = Invoice::with(['client.user'])
+            ->orderByDesc('created_at')
+            ->limit(6)
+            ->get();
+
+        $recentPayments = Payment::with(['invoice.client.user'])
+            ->orderByDesc('created_at')
+            ->limit(6)
+            ->get();
+
+        $recentTickets = Ticket::with(['client.user'])
+            ->orderByDesc('updated_at')
+            ->limit(6)
+            ->get();
+
+        $loginActivities = LoginActivity::with('user')
+            ->orderByDesc('created_at')
+            ->limit(10)
+            ->get();
+
+        return view('admin.dashboard', [
+            'stats' => $stats,
+            'revenueLabels' => $revenueSeries['labels'],
+            'revenueValues' => $revenueSeries['values'],
+            'upcomingRenewals' => $upcomingRenewals,
+            'recentInvoices' => $recentInvoices,
+            'recentPayments' => $recentPayments,
+            'recentTickets' => $recentTickets,
+            'loginActivities' => $loginActivities,
+        ]);
+    }
+
+    protected function revenueSeries(Carbon $from, Carbon $to): array
+    {
+        $paidInvoices = Invoice::where('status', 'paid')
+            ->whereNotNull('paid_at')
+            ->whereBetween('paid_at', [$from->copy(), $to->copy()])
+            ->get()
+            ->groupBy(function (Invoice $invoice) {
+                return $invoice->paid_at->format('Y-m');
+            })
+            ->map(function (Collection $group) {
+                return round($group->sum('total'), 2);
+            });
+
+        $labels = [];
+        $values = [];
+        $cursor = $from->copy();
+        while ($cursor->lte($to)) {
+            $key = $cursor->format('Y-m');
+            $labels[] = $cursor->translatedFormat('M Y');
+            $values[] = $paidInvoices->get($key, 0.0);
+            $cursor->addMonth();
+        }
+
+        return ['labels' => $labels, 'values' => $values];
+    }
+}

--- a/app/Http/Controllers/AdminPaymentsController.php
+++ b/app/Http/Controllers/AdminPaymentsController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\InvoicePaid;
+use App\Models\Payment;
+use App\Models\PaymentLog;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminPaymentsController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified', 'admin']);
+    }
+
+    public function index()
+    {
+        $payments = Payment::with(['invoice.client.user'])
+            ->where('gateway', 'manual')
+            ->where('status', 'pending')
+            ->orderByDesc('created_at')
+            ->paginate(15);
+        return view('admin.payments.index', compact('payments'));
+    }
+
+    public function confirm(Payment $payment, Request $request)
+    {
+        if ($payment->gateway !== 'manual') {
+            abort(400, 'Only manual payments can be confirmed');
+        }
+        if ($payment->status === 'completed') {
+            return redirect()->back()->with('status', 'Payment already confirmed');
+        }
+
+        $payment->status = 'completed';
+        $payment->paid_at = now();
+        $payment->meta = array_merge($payment->meta ?? [], [
+            'confirmed_by' => Auth::id(),
+            'confirmed_at' => now()->toDateTimeString(),
+        ]);
+        $payment->save();
+
+        $invoice = $payment->invoice;
+        if ($invoice && $invoice->status !== 'paid') {
+            $invoice->status = 'paid';
+            $invoice->paid_at = now();
+            $invoice->save();
+            event(new InvoicePaid($invoice));
+        }
+
+        PaymentLog::create([
+            'payment_id' => $payment->id,
+            'gateway' => $payment->gateway,
+            'event' => 'manual_confirmed',
+            'payload' => ['admin_id' => Auth::id()],
+            'ip_address' => $request->ip(),
+        ]);
+
+        return redirect()->back()->with('status', 'Payment confirmed and invoice marked as paid');
+    }
+}

--- a/app/Http/Controllers/AdminTicketController.php
+++ b/app/Http/Controllers/AdminTicketController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ticket;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminTicketController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified', 'admin']);
+    }
+
+    public function index(Request $request)
+    {
+        $status = $request->input('status');
+
+        $tickets = Ticket::with(['client.user'])
+            ->when($status, function ($query) use ($status) {
+                $query->where('status', $status);
+            })
+            ->orderByDesc('updated_at')
+            ->paginate(20)
+            ->appends(['status' => $status]);
+
+        return view('admin.tickets.index', compact('tickets', 'status'));
+    }
+
+    public function show(Ticket $ticket)
+    {
+        $ticket->load(['client.user', 'replies.user']);
+
+        return view('admin.tickets.show', compact('ticket'));
+    }
+
+    public function reply(Request $request, Ticket $ticket)
+    {
+        $data = $request->validate([
+            'message' => 'required|string|min:3',
+            'is_internal' => 'nullable|boolean',
+        ]);
+
+        $isInternal = (bool) ($data['is_internal'] ?? false);
+
+        $ticket->addReply(Auth::user(), $data['message'], $isInternal);
+
+        return redirect()->route('admin.tickets.show', $ticket)->with('status', $isInternal ? 'Internal note added.' : 'Reply sent to client.');
+    }
+
+    public function updateStatus(Request $request, Ticket $ticket)
+    {
+        $data = $request->validate([
+            'status' => 'required|string|in:open,closed',
+        ]);
+
+        $ticket->status = $data['status'];
+        if ($data['status'] === 'open') {
+            $ticket->last_reply_at = $ticket->last_reply_at ?? now();
+        }
+        $ticket->save();
+
+        return redirect()->route('admin.tickets.show', $ticket)->with('status', 'Ticket status updated.');
+    }
+}

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Support\EnvWriter;
+use App\Support\Settings;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class InstallController extends Controller
+{
+    public function index(Request $request)
+    {
+        if (config('app.installed')) {
+            return redirect()->route('admin.dashboard');
+        }
+
+        $requirements = $this->checkRequirements();
+        $databaseReady = $this->canConnectDatabase();
+
+        return view('install.index', [
+            'requirements' => $requirements,
+            'databaseReady' => $databaseReady,
+            'defaultAppName' => config('app.name', 'Billing Portal'),
+            'defaultUrl' => rtrim($request->getSchemeAndHttpHost(), '/'),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        if (config('app.installed')) {
+            return redirect()->route('admin.dashboard');
+        }
+
+        $data = $request->validate([
+            'app_name' => 'required|string|max:120',
+            'app_url' => 'required|url|max:255',
+            'admin_name' => 'required|string|max:120',
+            'admin_email' => 'required|email|max:255',
+            'admin_password' => 'required|string|min:8|confirmed',
+            'company_name' => 'required|string|max:150',
+            'company_email' => 'required|email|max:255',
+            'company_phone' => 'nullable|string|max:50',
+            'company_address' => 'nullable|string|max:1000',
+            'company_tax_id' => 'nullable|string|max:100',
+            'manual_instructions' => 'nullable|string|max:5000',
+            'tax_rate' => 'nullable|numeric|min:0|max:100',
+            'currency' => 'required|string|size:3',
+        ]);
+
+        try {
+            Artisan::call('migrate', ['--force' => true]);
+        } catch (Throwable $e) {
+            Log::error('Installation migrate failed', ['exception' => $e]);
+            return back()->withErrors(['app' => 'Failed to run database migrations: '.$e->getMessage()])->withInput();
+        }
+
+        DB::beginTransaction();
+        try {
+            $user = User::where('email', $data['admin_email'])->first();
+            if ($user) {
+                $user->name = $data['admin_name'];
+                $user->password = Hash::make($data['admin_password']);
+                $user->is_admin = true;
+                $user->email_verified_at = now();
+                $user->save();
+            } else {
+                $user = User::create([
+                    'name' => $data['admin_name'],
+                    'email' => $data['admin_email'],
+                    'password' => Hash::make($data['admin_password']),
+                    'is_admin' => true,
+                ]);
+                $user->forceFill(['email_verified_at' => now()])->save();
+            }
+
+            Settings::set('branding.name', $data['app_name']);
+            Settings::set('company.name', $data['company_name']);
+            Settings::set('company.email', $data['company_email']);
+            Settings::set('company.phone', (string) ($data['company_phone'] ?? ''));
+            Settings::set('company.address', (string) ($data['company_address'] ?? ''));
+            Settings::set('company.tax_id', (string) ($data['company_tax_id'] ?? ''));
+            Settings::set('company.currency', strtoupper($data['currency']));
+            Settings::set('payments.manual.instructions', (string) ($data['manual_instructions'] ?? ''));
+            Settings::set('payments.enabled', ['manual'], 'json');
+            if ($data['tax_rate'] !== null) {
+                Settings::set('finance.tax_rate', (float) $data['tax_rate'], 'float');
+            }
+
+            DB::commit();
+        } catch (Throwable $e) {
+            DB::rollBack();
+            Log::error('Installation setup failed', ['exception' => $e]);
+            return back()->withErrors(['app' => 'Failed to create admin user: '.$e->getMessage()])->withInput();
+        }
+
+        try {
+            EnvWriter::set([
+                'APP_NAME' => $data['app_name'],
+                'APP_URL' => $data['app_url'],
+                'APP_INSTALLED' => true,
+                'MAIL_FROM_ADDRESS' => $data['company_email'],
+                'MAIL_FROM_NAME' => $data['app_name'],
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Failed to update environment file', ['exception' => $e]);
+        }
+
+        config(['app.installed' => true, 'app.name' => $data['app_name']]);
+        Auth::login($user);
+
+        return redirect()->route('admin.dashboard')->with('status', 'Installation completed successfully.');
+    }
+
+    protected function checkRequirements(): array
+    {
+        $checks = [
+            'PHP >= 8.3' => version_compare(PHP_VERSION, '8.3.0', '>='),
+            'OpenSSL extension' => extension_loaded('openssl'),
+            'PDO extension' => extension_loaded('pdo'),
+            'Mbstring extension' => extension_loaded('mbstring'),
+            'JSON extension' => extension_loaded('json'),
+            'cURL extension' => extension_loaded('curl'),
+            'Storage writable' => is_writable(storage_path()),
+        ];
+
+        return $checks;
+    }
+
+    protected function canConnectDatabase(): bool
+    {
+        try {
+            DB::connection()->getPdo();
+            return true;
+        } catch (Throwable $e) {
+            Log::warning('Database connection failed during installation check', ['exception' => $e]);
+            return false;
+        }
+    }
+}

--- a/app/Http/Controllers/InvoiceCreditController.php
+++ b/app/Http/Controllers/InvoiceCreditController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Invoice;
+use App\Support\CreditManager;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class InvoiceCreditController extends Controller
+{
+    public function apply(Request $request, Invoice $invoice)
+    {
+        $user = Auth::user();
+        if (! $user) {
+            abort(401);
+        }
+        if (! $invoice->client || $invoice->client->user_id !== $user->id) {
+            abort(403);
+        }
+        if ($invoice->status === 'paid') {
+            return redirect()->back()->with('status', 'Invoice already settled.');
+        }
+
+        $data = $request->validate([
+            'amount' => 'nullable|numeric|min:0.01',
+        ]);
+
+        $amount = array_key_exists('amount', $data) ? (float) $data['amount'] : null;
+        $applied = CreditManager::applyToInvoice($invoice, $amount, $user->id, 'Client applied credit');
+
+        if ($applied <= 0) {
+            return redirect()->back()->withErrors(['amount' => 'Unable to apply credit to this invoice.']);
+        }
+
+        return redirect()->back()->with('status', 'Credit of '.number_format($applied, 2).' applied successfully.');
+    }
+}

--- a/app/Http/Controllers/InvoicesController.php
+++ b/app/Http/Controllers/InvoicesController.php
@@ -22,7 +22,7 @@ class InvoicesController extends Controller
         if (! $invoice->client || $invoice->client->user_id !== $user->id) abort(403);
         $available = [];
         foreach ($gateways->all() as $k => $g) { $available[] = ['key'=>$k,'name'=>$g->displayName()]; }
-        return view('invoices.show', [ 'invoice'=>$invoice->load(['items','client.user']), 'gateways'=>$available ]);
+        return view('invoices.show', [ 'invoice'=>$invoice->load(['items','client.user','payments']), 'gateways'=>$available ]);
     }
 }
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -18,7 +18,8 @@ class OrderController extends Controller
     {
         $data=$request->validate(['product_id'=>'required|exists:products,id','billing_cycle'=>'sometimes|string|in:monthly,quarterly,semiannually,annually']);
         $user=Auth::user(); if(! $user) abort(401);
-        $client=Client::firstOrCreate(['user_id'=>$user->id]); $product=Product::findOrFail($data['product_id']);
+        $client=Client::firstOrCreate(['user_id'=>$user->id]);
+        $product=Product::where('is_active',true)->where('id',$data['product_id'])->firstOrFail();
         return DB::transaction(function() use($client,$product,$data){
             $service=Service::create(['client_id'=>$client->id,'product_id'=>$product->id,'status'=>'pending','billing_cycle'=>$data['billing_cycle']??'monthly','meta'=>['driver'=>'virtfusion','plan'=>$product->options]]);
             $subtotal=$product->base_price;

--- a/app/Http/Controllers/PaymentWebhookController.php
+++ b/app/Http/Controllers/PaymentWebhookController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Domain\Payments\GatewayManager;
 use App\Support\Idempotency;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 
 class PaymentWebhookController extends Controller
 {
@@ -14,7 +15,11 @@ class PaymentWebhookController extends Controller
         if (! Idempotency::claim($gateway, $raw)) {
             return response()->json(['ok'=>true,'duplicate'=>true]);
         }
-        $gateways->get($gateway)->handleWebhook($request);
+        try {
+            $gateways->get($gateway)->handleWebhook($request);
+        } catch (InvalidArgumentException $e) {
+            return response()->json(['error' => 'Gateway not found'], 404);
+        }
         return response()->json(['ok'=>true]);
     }
 }

--- a/app/Http/Controllers/ServiceActionsController.php
+++ b/app/Http/Controllers/ServiceActionsController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Provisioning\ProvisioningManager;
+use App\Models\Service;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class ServiceActionsController extends Controller
+{
+    protected function assertOwned(Service $service): void
+    {
+        $service->loadMissing('client');
+        $user = Auth::user();
+        if (! $user || ! $service->client || $service->client->user_id !== $user->id) {
+            abort(403);
+        }
+    }
+
+    protected function perform(Service $service, ProvisioningManager $manager, callable $action, string $successMessage, array $allowedStatuses = ['active'])
+    {
+        $this->assertOwned($service);
+        if (! in_array($service->status, $allowedStatuses, true)) {
+            return redirect()->back()->with('error', 'Service is not in a state that allows this action');
+        }
+        $driverKey = $service->meta['driver'] ?? 'virtfusion';
+        try {
+            $driver = $manager->get($driverKey);
+            $action($driver, $service);
+            $service->refresh();
+        } catch (\Throwable $e) {
+            Log::error('Service action failed', [
+                'service_id' => $service->id,
+                'driver' => $driverKey,
+                'action' => $successMessage,
+                'exception' => $e,
+            ]);
+
+            return redirect()->back()->with('error', 'Unable to complete the requested action. Please try again or contact support.');
+        }
+        return redirect()->back()->with('status', $successMessage);
+    }
+
+    public function reboot(Service $service, ProvisioningManager $manager)
+    {
+        return $this->perform($service, $manager, function ($driver, Service $svc) {
+            $driver->reboot($svc);
+        }, 'Reboot command sent');
+    }
+
+    public function powerOn(Service $service, ProvisioningManager $manager)
+    {
+        return $this->perform($service, $manager, function ($driver, Service $svc) {
+            $driver->powerOn($svc);
+        }, 'Power on command sent');
+    }
+
+    public function powerOff(Service $service, ProvisioningManager $manager)
+    {
+        return $this->perform($service, $manager, function ($driver, Service $svc) {
+            $driver->powerOff($svc);
+        }, 'Power off command sent');
+    }
+
+    public function resetPassword(Service $service, ProvisioningManager $manager)
+    {
+        return $this->perform($service, $manager, function ($driver, Service $svc) {
+            $driver->resetPassword($svc);
+        }, 'Password reset successfully requested');
+    }
+
+    public function console(Service $service, ProvisioningManager $manager)
+    {
+        $this->assertOwned($service);
+        if ($service->status === 'terminated') {
+            return redirect()->back()->with('error', 'Console is unavailable for terminated services');
+        }
+        $driverKey = $service->meta['driver'] ?? 'virtfusion';
+        try {
+            $driver = $manager->get($driverKey);
+            $url = $driver->consoleUrl($service);
+        } catch (\Throwable $e) {
+            Log::error('Service console launch failed', [
+                'service_id' => $service->id,
+                'driver' => $driverKey,
+                'exception' => $e,
+            ]);
+
+            return redirect()->back()->with('error', 'Unable to open the console right now. Please try again or contact support.');
+        }
+        if (! $url) {
+            return redirect()->back()->with('error', 'Console is temporarily unavailable. Please try again later.');
+        }
+        return redirect()->away($url);
+    }
+}

--- a/app/Http/Controllers/ServiceController.php
+++ b/app/Http/Controllers/ServiceController.php
@@ -10,7 +10,7 @@ class ServiceController extends Controller
     public function index()
     {
         $user = Auth::user(); if (! $user) abort(401);
-        $services = $user->client ? $user->client->services()->latest()->paginate(15) : collect();
+        $services = $user->client ? $user->client->services()->with('product')->latest()->paginate(15) : collect();
         return view('services.index', compact('services'));
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ticket;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TicketController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified']);
+    }
+
+    public function index()
+    {
+        $user = Auth::user();
+        $client = $user?->client;
+        if (! $client) {
+            abort(403);
+        }
+
+        $tickets = Ticket::forClient($client)->latest('updated_at')->paginate(15);
+
+        return view('tickets.index', compact('tickets'));
+    }
+
+    public function create()
+    {
+        return view('tickets.create');
+    }
+
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        $client = $user?->client;
+        if (! $client) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'subject' => 'required|string|max:150',
+            'department' => 'nullable|string|max:100',
+            'priority' => 'required|string|in:low,normal,high',
+            'message' => 'required|string|min:10',
+        ]);
+
+        $ticket = Ticket::create([
+            'client_id' => $client->id,
+            'subject' => $data['subject'],
+            'department' => $data['department'] ?? null,
+            'priority' => $data['priority'],
+            'status' => 'open',
+        ]);
+
+        $ticket->addReply($user, $data['message']);
+
+        return redirect()->route('tickets.show', $ticket)->with('status', 'Support ticket created.');
+    }
+
+    public function show(Ticket $ticket)
+    {
+        $user = Auth::user();
+        $client = $user?->client;
+        if (! $client || $ticket->client_id !== $client->id) {
+            abort(403);
+        }
+
+        $ticket->load(['replies.user']);
+
+        return view('tickets.show', compact('ticket'));
+    }
+
+    public function reply(Request $request, Ticket $ticket)
+    {
+        $user = Auth::user();
+        $client = $user?->client;
+        if (! $client || $ticket->client_id !== $client->id) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'message' => 'required|string|min:5',
+        ]);
+
+        $ticket->addReply($user, $data['message']);
+
+        return redirect()->route('tickets.show', $ticket)->with('status', 'Reply sent to support.');
+    }
+
+    public function close(Ticket $ticket)
+    {
+        $user = Auth::user();
+        $client = $user?->client;
+        if (! $client || $ticket->client_id !== $client->id) {
+            abort(403);
+        }
+
+        $ticket->status = 'closed';
+        $ticket->save();
+
+        return redirect()->route('tickets.show', $ticket)->with('status', 'Ticket closed.');
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends HttpKernel
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
+            \App\Http\Middleware\EnsureAppInstalled::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
 
@@ -62,5 +63,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'installed' => \App\Http\Middleware\EnsureAppInstalled::class,
+        'admin' => \App\Http\Middleware\EnsureUserIsAdmin::class,
     ];
 }

--- a/app/Http/Middleware/EnsureAppInstalled.php
+++ b/app/Http/Middleware/EnsureAppInstalled.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureAppInstalled
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (app()->runningInConsole()) {
+            return $next($request);
+        }
+
+        $installed = (bool) config('app.installed', false);
+        $isInstallRoute = $request->is('install') || $request->is('install/*');
+        $isPublic = $request->is('storage/*') || $request->is('vendor/*') || $request->is('js/*') || $request->is('css/*') || $request->is('health');
+
+        if (! $installed) {
+            if ($isInstallRoute || $isPublic) {
+                return $next($request);
+            }
+
+            return redirect()->route('install.index');
+        }
+
+        if ($installed && $isInstallRoute) {
+            return redirect()->to('/');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class EnsureUserIsAdmin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = Auth::user();
+        if (! $user || ! $user->is_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array
      */
     protected $except = [
-        //
+        'webhook/payments/*',
     ];
 }

--- a/app/Jobs/SuspendServiceJob.php
+++ b/app/Jobs/SuspendServiceJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Domain\Provisioning\ProvisioningManager;
+use App\Models\Service;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SuspendServiceJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $serviceId;
+    public $tries = 3;
+
+    public function __construct(int $serviceId)
+    {
+        $this->serviceId = $serviceId;
+    }
+
+    public function backoff(): array
+    {
+        return [10, 30, 120];
+    }
+
+    public function handle(ProvisioningManager $manager): void
+    {
+        $service = Service::find($this->serviceId);
+        if (! $service) {
+            return;
+        }
+        if (in_array($service->status, ['pending', 'terminated'], true)) {
+            return;
+        }
+        if ($service->status === 'suspended') {
+            return;
+        }
+        $driverKey = $service->meta['driver'] ?? 'virtfusion';
+        $driver = $manager->get($driverKey);
+        $driver->suspend($service);
+        $service->status = 'suspended';
+        $service->suspended_at = now();
+        $service->save();
+    }
+}

--- a/app/Jobs/UnsuspendServiceJob.php
+++ b/app/Jobs/UnsuspendServiceJob.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Domain\Provisioning\ProvisioningManager;
+use App\Models\Service;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UnsuspendServiceJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $serviceId;
+    public $tries = 3;
+
+    public function __construct(int $serviceId)
+    {
+        $this->serviceId = $serviceId;
+    }
+
+    public function backoff(): array
+    {
+        return [10, 30, 120];
+    }
+
+    public function handle(ProvisioningManager $manager): void
+    {
+        $service = Service::find($this->serviceId);
+        if (! $service) {
+            return;
+        }
+        if ($service->status !== 'suspended') {
+            return;
+        }
+        $driverKey = $service->meta['driver'] ?? 'virtfusion';
+        $driver = $manager->get($driverKey);
+        $driver->unsuspend($service);
+        $service->status = 'active';
+        $service->suspended_at = null;
+        $service->save();
+    }
+}

--- a/app/Listeners/LogFailedLogin.php
+++ b/app/Listeners/LogFailedLogin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\LoginActivity;
+use Illuminate\Auth\Events\Failed;
+
+class LogFailedLogin
+{
+    public function handle(Failed $event): void
+    {
+        $request = request();
+
+        LoginActivity::create([
+            'user_id' => $event->user?->id,
+            'event' => 'failed',
+            'identifier' => $event->credentials['email'] ?? null,
+            'ip_address' => $request->ip(),
+            'user_agent' => substr((string) $request->userAgent(), 0, 500),
+        ]);
+    }
+}

--- a/app/Listeners/LogLogout.php
+++ b/app/Listeners/LogLogout.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\LoginActivity;
+use Illuminate\Auth\Events\Logout;
+
+class LogLogout
+{
+    public function handle(Logout $event): void
+    {
+        $request = request();
+
+        LoginActivity::create([
+            'user_id' => $event->user?->id,
+            'event' => 'logout',
+            'identifier' => $event->user?->email,
+            'ip_address' => $request->ip(),
+            'user_agent' => substr((string) $request->userAgent(), 0, 500),
+        ]);
+    }
+}

--- a/app/Listeners/LogSuccessfulLogin.php
+++ b/app/Listeners/LogSuccessfulLogin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\LoginActivity;
+use Illuminate\Auth\Events\Login;
+
+class LogSuccessfulLogin
+{
+    public function handle(Login $event): void
+    {
+        $request = request();
+
+        LoginActivity::create([
+            'user_id' => $event->user?->id,
+            'event' => 'login',
+            'identifier' => $event->user?->email,
+            'ip_address' => $request->ip(),
+            'user_agent' => substr((string) $request->userAgent(), 0, 500),
+        ]);
+    }
+}

--- a/app/Listeners/ProvisionServiceOnInvoicePaid.php
+++ b/app/Listeners/ProvisionServiceOnInvoicePaid.php
@@ -4,12 +4,33 @@ namespace App\Listeners;
 
 use App\Events\InvoicePaid;
 use App\Jobs\ProvisionServiceJob;
+use App\Jobs\UnsuspendServiceJob;
+use App\Support\ServiceBilling;
 
 class ProvisionServiceOnInvoicePaid
 {
     public function handle(InvoicePaid $event)
     {
-        $invoice=$event->invoice; $items=$invoice->items()->whereNotNull('service_id')->get();
-        foreach($items as $it){ dispatch(new ProvisionServiceJob($it->service_id)); }
+        $invoice=$event->invoice->loadMissing('items.service');
+        $processed=[];
+        foreach($invoice->items as $it){
+            if(! $it->service) continue;
+            $service=$it->service;
+            if(in_array($service->id,$processed,true)) continue;
+            $processed[]=$service->id;
+            if($service->status==='pending'){
+                dispatch(new ProvisionServiceJob($service->id));
+                continue;
+            }
+            ServiceBilling::advanceNextDueDate($service);
+            $meta=$service->meta??[];
+            $meta['last_payment_invoice_id']=$invoice->id;
+            $meta['last_payment_at']=now()->toDateTimeString();
+            $service->meta=$meta;
+            $service->save();
+            if($service->status==='suspended'){
+                dispatch(new UnsuspendServiceJob($service->id));
+            }
+        }
     }
 }

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -13,8 +13,14 @@ class Client extends Model
         'user_id','company','phone','address_line1','address_line2','city','state','country','postal_code','tax_id','credit_balance','currency'
     ];
 
+    protected $casts = [
+        'credit_balance' => 'float',
+    ];
+
     public function user(){ return $this->belongsTo(User::class); }
     public function services(){ return $this->hasMany(Service::class); }
     public function invoices(){ return $this->hasMany(Invoice::class); }
+    public function creditTransactions(){ return $this->hasMany(ClientCreditTransaction::class); }
+    public function tickets(){ return $this->hasMany(Ticket::class); }
 }
 

--- a/app/Models/ClientCreditTransaction.php
+++ b/app/Models/ClientCreditTransaction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClientCreditTransaction extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id',
+        'type',
+        'amount',
+        'balance_after',
+        'description',
+        'meta',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'amount' => 'float',
+        'balance_after' => 'float',
+        'meta' => 'array',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function admin()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/LoginActivity.php
+++ b/app/Models/LoginActivity.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LoginActivity extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'event',
+        'identifier',
+        'ip_address',
+        'user_agent',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -10,6 +10,20 @@ class Payment extends Model
     use HasFactory;
     protected $fillable = ['invoice_id','gateway','amount','currency','transaction_id','status','paid_at','meta'];
     protected $casts = ['paid_at'=>'datetime','meta'=>'array'];
+
+    protected static function booted()
+    {
+        $syncInvoice = function (Payment $payment) {
+            if ($payment->relationLoaded('invoice')) {
+                $payment->invoice->refresh();
+            }
+            optional($payment->invoice)->refreshPaymentStatus();
+        };
+
+        static::saved($syncInvoice);
+        static::deleted($syncInvoice);
+    }
+
     public function invoice(){ return $this->belongsTo(Invoice::class); }
     public function logs(){ return $this->hasMany(PaymentLog::class); }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+class Ticket extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id',
+        'reference',
+        'subject',
+        'status',
+        'priority',
+        'department',
+        'last_reply_at',
+        'last_reply_by',
+    ];
+
+    protected $casts = [
+        'last_reply_at' => 'datetime',
+    ];
+
+    protected static function booted()
+    {
+        static::creating(function (Ticket $ticket) {
+            if (empty($ticket->reference)) {
+                $ticket->reference = static::generateReference();
+            }
+        });
+    }
+
+    public static function generateReference(): string
+    {
+        return DB::transaction(function () {
+            $key = 'ticket:'.date('Ym');
+            $row = DB::table('counters')->where('key', $key)->lockForUpdate()->first();
+            if (! $row) {
+                DB::table('counters')->insert([
+                    'key' => $key,
+                    'value' => 1,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $seq = 1;
+            } else {
+                $seq = $row->value + 1;
+                DB::table('counters')->where('key', $key)->update([
+                    'value' => $seq,
+                    'updated_at' => now(),
+                ]);
+            }
+
+            return sprintf('TCK-%s-%04d', date('Ym'), $seq);
+        });
+    }
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(TicketReply::class)->orderBy('created_at');
+    }
+
+    public function lastResponder()
+    {
+        return $this->belongsTo(User::class, 'last_reply_by');
+    }
+
+    public function addReply(?User $user, string $message, bool $isInternal = false): TicketReply
+    {
+        $reply = $this->replies()->create([
+            'user_id' => $user?->id,
+            'message' => $message,
+            'is_internal' => $isInternal,
+        ]);
+
+        $this->last_reply_at = now();
+        $this->last_reply_by = $user?->id;
+        if (! $isInternal) {
+            $this->status = $user && $user->is_admin ? 'answered' : 'open';
+        }
+        $this->save();
+
+        return $reply;
+    }
+
+    public function scopeForClient($query, Client $client)
+    {
+        return $query->where('client_id', $client->id);
+    }
+}

--- a/app/Models/TicketReply.php
+++ b/app/Models/TicketReply.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TicketReply extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ticket_id',
+        'user_id',
+        'message',
+        'is_internal',
+    ];
+
+    protected $casts = [
+        'is_internal' => 'boolean',
+    ];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,14 +3,15 @@
 namespace App\Providers;
 
 use App\Domain\Payments\GatewayManager;
-use App\Domain\Payments\Gateways\MidtransGateway;
-use App\Domain\Payments\Gateways\XenditGateway;
-use App\Domain\Payments\Gateways\TripayGateway;
 use App\Domain\Payments\Gateways\DuitkuGateway;
-use App\Domain\Payments\Gateways\StripeGateway;
 use App\Domain\Payments\Gateways\ManualGateway;
-use App\Domain\Provisioning\ProvisioningManager;
+use App\Domain\Payments\Gateways\MidtransGateway;
+use App\Domain\Payments\Gateways\StripeGateway;
+use App\Domain\Payments\Gateways\TripayGateway;
+use App\Domain\Payments\Gateways\XenditGateway;
 use App\Domain\Provisioning\Drivers\VirtfusionDriver;
+use App\Domain\Provisioning\ProvisioningManager;
+use App\Support\ModuleToggle;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -25,13 +26,29 @@ class AppServiceProvider extends ServiceProvider
     {
         // Payment gateways registry
         $this->app->singleton(GatewayManager::class, function(){
-            $m=new GatewayManager();
-            $m->register(new MidtransGateway());
-            $m->register(new XenditGateway());
-            $m->register(new TripayGateway());
-            $m->register(new DuitkuGateway());
-            $m->register(new StripeGateway());
-            $m->register(new ManualGateway());
+            $m = new GatewayManager();
+            $enabled = ModuleToggle::gateways();
+            $restrict = is_array($enabled) && ! empty($enabled);
+
+            $gateways = [
+                new MidtransGateway(),
+                new XenditGateway(),
+                new TripayGateway(),
+                new DuitkuGateway(),
+                new StripeGateway(),
+                new ManualGateway(),
+            ];
+
+            foreach ($gateways as $gateway) {
+                if ($restrict && ! in_array($gateway->key(), $enabled, true)) {
+                    continue;
+                }
+
+                if ($gateway->isConfigured()) {
+                    $m->register($gateway);
+                }
+            }
+
             return $m;
         });
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,11 +3,17 @@
 namespace App\Providers;
 
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
 use App\Events\InvoicePaid;
 use App\Listeners\ProvisionServiceOnInvoicePaid;
+use App\Listeners\LogSuccessfulLogin;
+use App\Listeners\LogFailedLogin;
+use App\Listeners\LogLogout;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -19,6 +25,15 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        Login::class => [
+            LogSuccessfulLogin::class,
+        ],
+        Logout::class => [
+            LogLogout::class,
+        ],
+        Failed::class => [
+            LogFailedLogin::class,
         ],
         InvoicePaid::class => [
             ProvisionServiceOnInvoicePaid::class,

--- a/app/Support/CreditManager.php
+++ b/app/Support/CreditManager.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Client;
+use App\Models\ClientCreditTransaction;
+use App\Models\Invoice;
+use App\Models\Payment;
+use Illuminate\Support\Facades\DB;
+
+class CreditManager
+{
+    public static function addCredit(Client $client, float $amount, string $description = '', ?int $adminId = null, array $meta = []): ClientCreditTransaction
+    {
+        return static::adjust($client, abs($amount), 'credit', $description, $adminId, $meta);
+    }
+
+    public static function deductCredit(Client $client, float $amount, string $description = '', ?int $adminId = null, array $meta = []): ClientCreditTransaction
+    {
+        return static::adjust($client, abs($amount), 'debit', $description, $adminId, $meta);
+    }
+
+    protected static function adjust(Client $client, float $amount, string $type, string $description = '', ?int $adminId = null, array $meta = []): ClientCreditTransaction
+    {
+        return DB::transaction(function () use ($client, $amount, $type, $description, $adminId, $meta) {
+            $freshClient = Client::whereKey($client->id)->lockForUpdate()->firstOrFail();
+
+            if ($type === 'debit' && $freshClient->credit_balance < $amount) {
+                $amount = $freshClient->credit_balance;
+            }
+
+            if ($amount <= 0) {
+                return new ClientCreditTransaction([
+                    'client_id' => $freshClient->id,
+                    'type' => $type,
+                    'amount' => 0.0,
+                    'balance_after' => $freshClient->credit_balance,
+                ]);
+            }
+
+            if ($type === 'credit') {
+                $freshClient->credit_balance = round($freshClient->credit_balance + $amount, 2);
+            } else {
+                $freshClient->credit_balance = round($freshClient->credit_balance - $amount, 2);
+            }
+            $freshClient->save();
+
+            $transaction = $freshClient->creditTransactions()->create([
+                'type' => $type,
+                'amount' => round($amount, 2),
+                'balance_after' => $freshClient->credit_balance,
+                'description' => $description,
+                'meta' => $meta,
+                'created_by' => $adminId,
+            ]);
+
+            $client->refresh();
+
+            return $transaction;
+        });
+    }
+
+    public static function applyToInvoice(Invoice $invoice, ?float $maxAmount = null, ?int $adminId = null, string $description = ''): float
+    {
+        $client = $invoice->client;
+        if (! $client) {
+            return 0.0;
+        }
+
+        return DB::transaction(function () use ($invoice, $client, $maxAmount, $adminId, $description) {
+            $freshClient = Client::whereKey($client->id)->lockForUpdate()->firstOrFail();
+            $freshInvoice = Invoice::whereKey($invoice->id)->lockForUpdate()->firstOrFail();
+
+            $outstanding = $freshInvoice->balanceDue();
+            $available = $freshClient->credit_balance;
+            if ($maxAmount !== null) {
+                $available = min($available, $maxAmount);
+            }
+            $apply = round(min($available, $outstanding), 2);
+
+            if ($apply <= 0) {
+                return 0.0;
+            }
+
+            $freshClient->credit_balance = round($freshClient->credit_balance - $apply, 2);
+            $freshClient->save();
+
+            $transaction = $freshClient->creditTransactions()->create([
+                'type' => 'debit',
+                'amount' => $apply,
+                'balance_after' => $freshClient->credit_balance,
+                'description' => $description ?: 'Applied to invoice '.$freshInvoice->number,
+                'meta' => ['invoice_id' => $freshInvoice->id],
+                'created_by' => $adminId,
+            ]);
+
+            $payment = Payment::create([
+                'invoice_id' => $freshInvoice->id,
+                'gateway' => 'credit',
+                'amount' => $apply,
+                'currency' => $freshInvoice->currency,
+                'status' => 'completed',
+                'paid_at' => now(),
+                'meta' => ['credit_transaction_id' => $transaction->id],
+            ]);
+
+            $freshInvoice->refreshPaymentStatus();
+
+            $client->refresh();
+            $invoice->refresh();
+
+            return $apply;
+        });
+    }
+}

--- a/app/Support/EnvWriter.php
+++ b/app/Support/EnvWriter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Support;
+
+use RuntimeException;
+
+class EnvWriter
+{
+    protected static ?string $customPath = null;
+
+    public static function usePath(?string $path): void
+    {
+        static::$customPath = $path;
+    }
+
+    protected static function path(): string
+    {
+        return static::$customPath ?? base_path('.env');
+    }
+
+    public static function set(array $values): void
+    {
+        $path = static::path();
+        if (! file_exists($path)) {
+            $example = base_path('.env.example');
+            if (file_exists($example)) {
+                copy($example, $path);
+            } else {
+                file_put_contents($path, '');
+            }
+        }
+
+        $content = file_get_contents($path);
+        if ($content === false) {
+            throw new RuntimeException('Unable to read environment file.');
+        }
+
+        foreach ($values as $key => $value) {
+            $formatted = static::formatValue($value);
+            $pattern = "/^".preg_quote($key, '/')."=.*$/m";
+            $replacement = $key.'='.$formatted;
+            $updated = preg_replace($pattern, $replacement, $content);
+            if ($updated === null) {
+                throw new RuntimeException('Unable to update environment file.');
+            }
+            if ($updated === $content) {
+                $content = rtrim($content).PHP_EOL.$replacement;
+            } else {
+                $content = $updated;
+            }
+        }
+
+        file_put_contents($path, $content.PHP_EOL);
+    }
+
+    protected static function formatValue($value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_null($value)) {
+            return 'null';
+        }
+
+        $string = (string) $value;
+        $needsQuotes = strpbrk($string, " #\n\r\t") !== false;
+        if ($needsQuotes) {
+            return '"'.addslashes($string).'"';
+        }
+
+        return $string;
+    }
+}

--- a/app/Support/ServiceBilling.php
+++ b/app/Support/ServiceBilling.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Service;
+use Carbon\Carbon;
+
+class ServiceBilling
+{
+    public static function addCycle(Carbon $from, string $cycle): Carbon
+    {
+        $next = $from->copy();
+        switch ($cycle) {
+            case 'annually':
+                $next->addYear();
+                break;
+            case 'semiannually':
+                $next->addMonths(6);
+                break;
+            case 'quarterly':
+                $next->addMonths(3);
+                break;
+            case 'monthly':
+            default:
+                $next->addMonth();
+                break;
+        }
+        return $next->startOfDay();
+    }
+
+    public static function initialDueDate(Service $service, ?Carbon $reference = null): Carbon
+    {
+        $base = $reference ? $reference->copy() : now();
+        return static::addCycle($base, $service->billing_cycle ?: 'monthly');
+    }
+
+    public static function advanceNextDueDate(Service $service): void
+    {
+        $base = $service->next_due_date ? $service->next_due_date->copy() : now();
+        $service->next_due_date = static::addCycle($base, $service->billing_cycle ?: 'monthly');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^8.3",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "facade/ignition": "^2.3.6",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.23",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3"
@@ -26,7 +26,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "8.3.0"
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "175bdd825f15b92114bc5d8ba8538463",
+    "content-hash": "ec3455dee10b47dc4076ebf0c08ea21d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3305,20 +3305,20 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.4",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
@@ -3327,7 +3327,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3352,7 +3352,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3368,7 +3368,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -5817,6 +5817,69 @@
             "time": "2020-10-16T08:27:54+00:00"
         },
         {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
+        },
+        {
             "name": "filp/whoops",
             "version": "2.18.4",
             "source": {
@@ -5886,61 +5949,6 @@
                 }
             ],
             "time": "2025-08-08T12:00:00+00:00"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "squizlabs/php_codesniffer": "^2.9.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "support": {
-                "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
-            },
-            "abandoned": true,
-            "time": "2020-12-11T09:56:16+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7827,8 +7835,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3"
+        "php": "^8.3"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,8 @@ return [
 
     'asset_url' => env('ASSET_URL', null),
 
+    'installed' => (bool) env('APP_INSTALLED', false),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/database/migrations/2025_09_15_131650_add_admin_fields_to_users_table.php
+++ b/database/migrations/2025_09_15_131650_add_admin_fields_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAdminFieldsToUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'phone')) {
+                $table->string('phone')->nullable()->after('email');
+            }
+            if (! Schema::hasColumn('users', 'is_admin')) {
+                $table->boolean('is_admin')->default(false)->after('remember_token');
+            }
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'phone')) {
+                $table->dropColumn('phone');
+            }
+            if (Schema::hasColumn('users', 'is_admin')) {
+                $table->dropColumn('is_admin');
+            }
+        });
+    }
+}

--- a/database/migrations/2025_09_15_131700_create_client_credit_transactions_table.php
+++ b/database/migrations/2025_09_15_131700_create_client_credit_transactions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('client_credit_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('client_id');
+            $table->string('type');
+            $table->decimal('amount', 12, 2);
+            $table->decimal('balance_after', 12, 2);
+            $table->string('description')->nullable();
+            $table->json('meta')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('client_id')->references('id')->on('clients')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->nullOnDelete();
+            $table->index(['client_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_credit_transactions');
+    }
+};

--- a/database/migrations/2025_09_15_131720_create_tickets_table.php
+++ b/database/migrations/2025_09_15_131720_create_tickets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tickets', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('client_id');
+            $table->string('reference')->unique();
+            $table->string('subject');
+            $table->string('status')->default('open');
+            $table->string('priority')->default('normal');
+            $table->string('department')->nullable();
+            $table->timestamp('last_reply_at')->nullable();
+            $table->unsignedBigInteger('last_reply_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('client_id')->references('id')->on('clients')->onDelete('cascade');
+            $table->foreign('last_reply_by')->references('id')->on('users')->nullOnDelete();
+            $table->index(['client_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tickets');
+    }
+};

--- a/database/migrations/2025_09_15_131730_create_ticket_replies_table.php
+++ b/database/migrations/2025_09_15_131730_create_ticket_replies_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_replies', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('ticket_id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->text('message');
+            $table->boolean('is_internal')->default(false);
+            $table->timestamps();
+
+            $table->foreign('ticket_id')->references('id')->on('tickets')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['ticket_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_replies');
+    }
+};

--- a/database/migrations/2025_09_15_131740_create_login_activities_table.php
+++ b/database/migrations/2025_09_15_131740_create_login_activities_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('login_activities', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('event');
+            $table->string('identifier')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+            $table->index(['event', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('login_activities');
+    }
+};

--- a/resources/views/admin/clients/index.blade.php
+++ b/resources/views/admin/clients/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+@section('content')
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3 class="mb-0">Clients</h3>
+    <form method="GET" class="form-inline">
+      <input type="text" class="form-control form-control-sm mr-2" name="q" value="{{ $search }}" placeholder="Search name, email or company">
+      <button class="btn btn-sm btn-primary" type="submit">Search</button>
+    </form>
+  </div>
+  <div class="card">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>Client</th>
+              <th>Company</th>
+              <th>Credit</th>
+              <th>Services</th>
+              <th class="text-right">Joined</th>
+            </tr>
+          </thead>
+          <tbody>
+            @forelse($clients as $client)
+              <tr onclick="window.location='{{ route('admin.clients.show', $client) }}'" style="cursor:pointer;">
+                <td>{{ optional($client->user)->name }}<br><small class="text-muted">{{ optional($client->user)->email }}</small></td>
+                <td>{{ $client->company ?? '—' }}</td>
+                <td>{{ number_format($client->credit_balance, 2) }} {{ $client->currency }}</td>
+                <td>{{ number_format($client->services_count) }}</td>
+                <td class="text-right">{{ optional($client->created_at)->format('Y-m-d') }}</td>
+              </tr>
+            @empty
+              <tr><td colspan="5" class="text-center p-4 text-muted">No clients found.</td></tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card-footer">{{ $clients->links() }}</div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/clients/show.blade.php
+++ b/resources/views/admin/clients/show.blade.php
@@ -1,0 +1,152 @@
+@extends('layouts.app')
+@section('content')
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h3 class="mb-0">{{ optional($client->user)->name }}</h3>
+      <small class="text-muted">{{ optional($client->user)->email }}</small>
+    </div>
+    <a href="{{ route('admin.clients.index') }}" class="btn btn-link">Back to clients</a>
+  </div>
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  <div class="row">
+    <div class="col-lg-4 mb-4">
+      <div class="card shadow-sm mb-4">
+        <div class="card-header">Profile</div>
+        <div class="card-body">
+          <p class="mb-1"><strong>Company:</strong> {{ $client->company ?? '—' }}</p>
+          <p class="mb-1"><strong>Phone:</strong> {{ $client->phone ?? '—' }}</p>
+          <p class="mb-1"><strong>Address:</strong><br>{{ $client->address_line1 ?? '' }} {{ $client->city }} {{ $client->country }}</p>
+          <p class="mb-0 text-muted">Registered {{ optional($client->created_at)->format('Y-m-d H:i') }}</p>
+        </div>
+      </div>
+      <div class="card shadow-sm">
+        <div class="card-header">Account Credit</div>
+        <div class="card-body">
+          <h4>{{ number_format($client->credit_balance, 2) }} {{ $client->currency }}</h4>
+          <form method="POST" action="{{ route('admin.clients.credit', $client) }}" class="mt-3">
+            @csrf
+            <div class="form-group">
+              <label>Type</label>
+              <select name="type" class="form-control" required>
+                <option value="credit">Add Credit</option>
+                <option value="debit">Deduct Credit</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Amount</label>
+              <input type="number" name="amount" step="0.01" min="0.01" class="form-control @error('amount') is-invalid @enderror" required>
+              @error('amount')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+            <div class="form-group">
+              <label>Description</label>
+              <input type="text" name="description" class="form-control @error('description') is-invalid @enderror" placeholder="Optional note">
+              @error('description')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+            <button class="btn btn-primary btn-block">Update Credit</button>
+          </form>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-8 mb-4">
+      <div class="card shadow-sm mb-4">
+        <div class="card-header">Active Services</div>
+        <div class="card-body p-0">
+          @if($services->isEmpty())
+            <p class="p-3 text-muted mb-0">Client has no services yet.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Service</th>
+                    <th>Status</th>
+                    <th>Cycle</th>
+                    <th>Next Due</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($services as $service)
+                    <tr>
+                      <td>{{ optional($service->product)->name ?? 'Service #'.$service->id }}</td>
+                      <td><span class="badge badge-{{ $service->status === 'active' ? 'success' : ($service->status === 'suspended' ? 'danger' : 'secondary') }}">{{ ucfirst($service->status) }}</span></td>
+                      <td>{{ ucfirst($service->billing_cycle) }}</td>
+                      <td>{{ optional($service->next_due_date)->format('Y-m-d') ?? '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+      <div class="card shadow-sm mb-4">
+        <div class="card-header">Recent Invoices</div>
+        <div class="card-body p-0">
+          @if($invoices->isEmpty())
+            <p class="p-3 text-muted mb-0">No invoices yet.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Invoice</th>
+                    <th>Status</th>
+                    <th>Total</th>
+                    <th>Due Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($invoices as $invoice)
+                    <tr>
+                      <td><a href="{{ url('/invoices/'.$invoice->id) }}">{{ $invoice->number }}</a></td>
+                      <td><span class="badge badge-{{ $invoice->status === 'paid' ? 'success' : ($invoice->status === 'overdue' ? 'danger' : 'warning') }}">{{ ucfirst($invoice->status) }}</span></td>
+                      <td>{{ number_format($invoice->total, 2) }} {{ $invoice->currency }}</td>
+                      <td>{{ optional($invoice->due_date)->format('Y-m-d') ?? '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+      <div class="card shadow-sm">
+        <div class="card-header">Credit Ledger</div>
+        <div class="card-body p-0">
+          @if($creditTransactions->isEmpty())
+            <p class="p-3 text-muted mb-0">No credit adjustments recorded.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Type</th>
+                    <th>Amount</th>
+                    <th>Balance</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($creditTransactions as $txn)
+                    <tr>
+                      <td>{{ optional($txn->created_at)->format('Y-m-d H:i') }}</td>
+                      <td>{{ ucfirst($txn->type) }}</td>
+                      <td>{{ number_format($txn->amount, 2) }} {{ $client->currency }}</td>
+                      <td>{{ number_format($txn->balance_after, 2) }} {{ $client->currency }}</td>
+                      <td>{{ $txn->description ?? '—' }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,276 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="d-flex align-items-center justify-content-between mb-4">
+    <div>
+      <h3 class="mb-0">Admin Dashboard</h3>
+      <small class="text-muted">Overview of clients, revenue, and infrastructure status.</small>
+    </div>
+    @if(session('status'))
+      <span class="badge badge-success p-2">{{ session('status') }}</span>
+    @endif
+  </div>
+  @php $currency = \App\Support\Settings::get('company.currency', 'IDR'); @endphp
+  <div class="row">
+    <div class="col-md-3 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted">Active Services</h6>
+          <h2 class="mb-0">{{ number_format($stats['active_services']) }}</h2>
+          <span class="text-success small">{{ number_format($stats['pending_services']) }} pending</span>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted">MRR (This Month)</h6>
+          <h2 class="mb-0">{{ number_format($stats['revenue_month'], 2) }} {{ $currency }}</h2>
+          <span class="text-muted small">{{ number_format($stats['revenue_30_days'], 2) }} {{ $currency }} in last 30 days</span>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted">Clients</h6>
+          <h2 class="mb-0">{{ number_format($stats['total_clients']) }}</h2>
+          <span class="text-muted small">{{ number_format($stats['new_clients_30_days']) }} joined in 30 days</span>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h6 class="text-muted">Billing Alerts</h6>
+          <h2 class="mb-0">{{ number_format($stats['pending_invoices']) }}</h2>
+          <span class="text-danger small">Overdue {{ number_format($stats['overdue_amount'], 2) }} {{ $currency }}</span>
+          <span class="text-muted small d-block mt-2">Open tickets {{ number_format($stats['open_tickets']) }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card mb-4 shadow-sm">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span>Revenue (last 6 months)</span>
+      <span class="badge badge-light">Manual payments pending: {{ number_format($stats['pending_manual_payments']) }}</span>
+    </div>
+    <div class="card-body">
+      <canvas id="revenueChart" height="120"></canvas>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header">Upcoming Renewals</div>
+        <div class="card-body p-0">
+          @if($upcomingRenewals->isEmpty())
+            <p class="p-3 text-muted mb-0">No active services approaching renewal.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Service</th>
+                    <th>Client</th>
+                    <th>Due Date</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($upcomingRenewals as $service)
+                    <tr>
+                      <td>{{ optional($service->product)->name ?? 'Service #'.$service->id }}</td>
+                      <td>{{ optional(optional($service->client)->user)->name ?? 'Unknown' }}</td>
+                      <td>{{ optional($service->next_due_date)->format('Y-m-d') ?? '—' }}</td>
+                      <td class="text-right"><span class="badge badge-secondary">{{ ucfirst($service->billing_cycle) }}</span></td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header">Recent Invoices</div>
+        <div class="card-body p-0">
+          @if($recentInvoices->isEmpty())
+            <p class="p-3 text-muted mb-0">Invoices will appear here after customers order services.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Invoice</th>
+                    <th>Client</th>
+                    <th>Status</th>
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($recentInvoices as $invoice)
+                    <tr>
+                      <td><a href="{{ url('/invoices/'.$invoice->id) }}">{{ $invoice->number }}</a></td>
+                      <td>{{ optional(optional($invoice->client)->user)->name ?? 'Unknown' }}</td>
+                      <td><span class="badge badge-{{ $invoice->status === 'paid' ? 'success' : ($invoice->status === 'overdue' ? 'danger' : 'warning') }}">{{ ucfirst($invoice->status) }}</span></td>
+                      <td>{{ number_format($invoice->total, 2) }} {{ $invoice->currency }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header">Recent Support Tickets</div>
+        <div class="card-body p-0">
+          @if($recentTickets->isEmpty())
+            <p class="p-3 text-muted mb-0">No support tickets have been submitted yet.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>Reference</th>
+                    <th>Client</th>
+                    <th>Status</th>
+                    <th class="text-right">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($recentTickets as $ticket)
+                    <tr>
+                      <td><a href="{{ route('admin.tickets.show', $ticket) }}">{{ $ticket->reference }}</a></td>
+                      <td>{{ optional(optional($ticket->client)->user)->name ?? 'Unknown' }}</td>
+                      <td><span class="badge badge-{{ $ticket->status==='closed'?'secondary':($ticket->status==='answered'?'info':'warning') }}">{{ ucfirst($ticket->status) }}</span></td>
+                      <td class="text-right">{{ optional($ticket->updated_at)->diffForHumans() }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header">Security Activity (Last 10)</div>
+        <div class="card-body p-0">
+          @if($loginActivities->isEmpty())
+            <p class="p-3 text-muted mb-0">Login history will appear after users authenticate.</p>
+          @else
+            <div class="table-responsive">
+              <table class="table table-striped mb-0">
+                <thead>
+                  <tr>
+                    <th>User</th>
+                    <th>Event</th>
+                    <th>IP</th>
+                    <th class="text-right">Timestamp</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @foreach($loginActivities as $activity)
+                    <tr>
+                      <td>{{ optional($activity->user)->name ?? $activity->identifier ?? 'Unknown' }}</td>
+                      <td><span class="badge badge-{{ $activity->event === 'failed' ? 'danger' : ($activity->event === 'login' ? 'success' : 'secondary') }}">{{ ucfirst($activity->event) }}</span></td>
+                      <td>{{ $activity->ip_address ?? '—' }}</td>
+                      <td class="text-right">{{ optional($activity->created_at)->format('Y-m-d H:i') }}</td>
+                    </tr>
+                  @endforeach
+                </tbody>
+              </table>
+            </div>
+          @endif
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-header">Recent Payments</div>
+    <div class="card-body p-0">
+      @if($recentPayments->isEmpty())
+        <p class="p-3 text-muted mb-0">Payment history will populate once customers are billed.</p>
+      @else
+        <div class="table-responsive">
+          <table class="table table-striped mb-0">
+            <thead>
+              <tr>
+                <th>Gateway</th>
+                <th>Amount</th>
+                <th>Status</th>
+                <th>Invoice</th>
+                <th>Paid At</th>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach($recentPayments as $payment)
+                <tr>
+                  <td class="text-uppercase">{{ $payment->gateway }}</td>
+                  <td>{{ number_format($payment->amount, 2) }} {{ $payment->currency }}</td>
+                  <td><span class="badge badge-{{ $payment->status === 'completed' ? 'success' : 'secondary' }}">{{ ucfirst($payment->status) }}</span></td>
+                  <td>
+                    @if($payment->invoice)
+                      <a href="{{ url('/invoices/'.$payment->invoice_id) }}">{{ optional($payment->invoice)->number }}</a>
+                    @else
+                      —
+                    @endif
+                  </td>
+                  <td>{{ optional($payment->paid_at)->format('Y-m-d H:i') ?? '—' }}</td>
+                </tr>
+              @endforeach
+            </tbody>
+          </table>
+        </div>
+      @endif
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-d3/6th10S9rNUz3omWeNdMf1sBhY9qsK0kGugHgdGXN53BJ38qRAjPR9U1FVLtZL" crossorigin="anonymous"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var ctx = document.getElementById('revenueChart');
+    if (!ctx) { return; }
+    var chart = new Chart(ctx.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: @json($revenueLabels),
+        datasets: [{
+          label: 'Revenue',
+          data: @json($revenueValues),
+          borderColor: '#007bff',
+          backgroundColor: 'rgba(0, 123, 255, 0.1)',
+          tension: 0.3,
+          fill: true,
+          borderWidth: 2,
+          pointRadius: 3,
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { beginAtZero: true }
+        }
+      }
+    });
+  });
+</script>
+@endpush

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+@section('content')
+<div class="container" style="max-width: 960px;">
+  <h3 class="mb-3">Pending Manual Payments</h3>
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  @if($payments->isEmpty())
+    <div class="alert alert-info">No pending manual payments.</div>
+  @else
+    <div class="card">
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped mb-0">
+            <thead>
+              <tr>
+                <th>Invoice</th>
+                <th>Client</th>
+                <th>Amount</th>
+                <th>Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach($payments as $payment)
+                <tr>
+                  <td><a href="{{ url('/invoices/'.$payment->invoice_id) }}">{{ optional($payment->invoice)->number ?? '—' }}</a></td>
+                  <td>{{ optional(optional(optional($payment->invoice)->client)->user)->name ?? 'Unknown' }}</td>
+                  <td>{{ number_format($payment->amount, 2) }} {{ $payment->currency }}</td>
+                  <td>{{ optional($payment->created_at)->format('Y-m-d H:i') }}</td>
+                  <td class="text-right">
+                    <form method="POST" action="{{ route('admin.payments.confirm', $payment) }}" onsubmit="return confirm('Mark this payment as received?');">
+                      @csrf
+                      <button class="btn btn-sm btn-success">Confirm</button>
+                    </form>
+                  </td>
+                </tr>
+              @endforeach
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="card-footer">{{ $payments->links() }}</div>
+    </div>
+  @endif
+</div>
+@endsection

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -5,7 +5,7 @@
   @if(session('status'))
     <div class="alert alert-success">{{ session('status') }}</div>
   @endif
-  <form method="POST" action="{{ url('/admin/settings') }}">
+  <form method="POST" action="{{ route('admin.settings.update') }}">
     @csrf
     <div class="card mb-3">
       <div class="card-header">Branding</div>

--- a/resources/views/admin/tickets/index.blade.php
+++ b/resources/views/admin/tickets/index.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+@section('content')
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3 class="mb-0">All Support Tickets</h3>
+    <div>
+      <form method="GET" class="form-inline">
+        <label class="mr-2 mb-0">Status</label>
+        <select name="status" class="form-control form-control-sm mr-2" onchange="this.form.submit()">
+          <option value="">All</option>
+          @foreach(['open'=>'Open','answered'=>'Answered','closed'=>'Closed'] as $value => $label)
+            <option value="{{ $value }}" {{ request('status')===$value?'selected':'' }}>{{ $label }}</option>
+          @endforeach
+        </select>
+        <noscript><button class="btn btn-sm btn-primary">Filter</button></noscript>
+      </form>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover mb-0">
+          <thead>
+            <tr>
+              <th>Reference</th>
+              <th>Subject</th>
+              <th>Client</th>
+              <th>Status</th>
+              <th>Priority</th>
+              <th class="text-right">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            @forelse($tickets as $ticket)
+              <tr onclick="window.location='{{ route('admin.tickets.show', $ticket) }}'" style="cursor:pointer;">
+                <td>{{ $ticket->reference }}</td>
+                <td>{{ $ticket->subject }}</td>
+                <td>{{ optional($ticket->client->user)->name ?? 'Unknown' }}</td>
+                <td><span class="badge badge-{{ $ticket->status==='closed'?'secondary':($ticket->status==='answered'?'info':'warning') }}">{{ ucfirst($ticket->status) }}</span></td>
+                <td>{{ ucfirst($ticket->priority) }}</td>
+                <td class="text-right">{{ optional($ticket->updated_at)->diffForHumans() }}</td>
+              </tr>
+            @empty
+              <tr><td colspan="6" class="text-center p-4 text-muted">No tickets found for this filter.</td></tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card-footer">{{ $tickets->links() }}</div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/tickets/show.blade.php
+++ b/resources/views/admin/tickets/show.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts.app')
+@section('content')
+<div class="container-fluid" style="max-width: 1100px;">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h3 class="mb-0">Ticket {{ $ticket->reference }}</h3>
+      <small class="text-muted">{{ $ticket->subject }} &middot; {{ optional($ticket->client->user)->name }}</small>
+    </div>
+    <div>
+      <a href="{{ route('admin.tickets.index') }}" class="btn btn-link">Back</a>
+      <form method="POST" action="{{ route('admin.tickets.status', $ticket) }}" class="d-inline">
+        @csrf
+        <input type="hidden" name="status" value="{{ $ticket->status === 'closed' ? 'open' : 'closed' }}">
+        <button class="btn btn-sm btn-outline-secondary" type="submit">{{ $ticket->status === 'closed' ? 'Reopen' : 'Close' }} Ticket</button>
+      </form>
+    </div>
+  </div>
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  <div class="row">
+    <div class="col-md-8">
+      @foreach($ticket->replies as $reply)
+        <div class="card mb-3">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+              <strong>{{ optional($reply->user)->name ?? 'System' }}</strong>
+              <small class="text-muted ml-2">{{ optional($reply->created_at)->format('Y-m-d H:i') }}</small>
+              @if($reply->is_internal)
+                <span class="badge badge-secondary ml-2">Internal</span>
+              @endif
+            </div>
+          </div>
+          <div class="card-body">
+            <pre class="mb-0" style="white-space: pre-wrap;">{{ $reply->message }}</pre>
+          </div>
+        </div>
+      @endforeach
+    </div>
+    <div class="col-md-4">
+      <div class="card mb-3">
+        <div class="card-body">
+          <div class="mb-2"><strong>Status:</strong> <span class="badge badge-{{ $ticket->status==='closed'?'secondary':($ticket->status==='answered'?'info':'warning') }}">{{ ucfirst($ticket->status) }}</span></div>
+          <div class="mb-2"><strong>Priority:</strong> {{ ucfirst($ticket->priority) }}</div>
+          @if($ticket->department)
+            <div class="mb-2"><strong>Department:</strong> {{ $ticket->department }}</div>
+          @endif
+          <div class="mb-2 text-muted">Opened {{ optional($ticket->created_at)->format('Y-m-d H:i') }}</div>
+          <div class="mb-0 text-muted">Updated {{ optional($ticket->updated_at)->diffForHumans() }}</div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header">Reply / Add Note</div>
+        <div class="card-body">
+          <form method="POST" action="{{ route('admin.tickets.reply', $ticket) }}">
+            @csrf
+            <div class="form-group">
+              <label>Message</label>
+              <textarea name="message" rows="6" class="form-control @error('message') is-invalid @enderror" required>{{ old('message') }}</textarea>
+              @error('message')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+            <div class="form-group form-check">
+              <input type="checkbox" class="form-check-input" id="is_internal" name="is_internal" value="1" {{ old('is_internal') ? 'checked' : '' }}>
+              <label class="form-check-label" for="is_internal">Internal note (hidden from client)</label>
+            </div>
+            <button class="btn btn-primary btn-block">Submit</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/install/index.blade.php
+++ b/resources/views/install/index.blade.php
@@ -1,0 +1,136 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container" style="max-width: 980px;">
+  <div class="row">
+    <div class="col-lg-4 mb-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-primary text-white">Environment Check</div>
+        <div class="card-body">
+          <p class="text-muted">Ensure the server meets the minimum requirements before continuing.</p>
+          <ul class="list-unstyled mb-0">
+            @foreach($requirements as $label => $status)
+              <li class="d-flex align-items-center mb-2">
+                <span class="badge badge-{{ $status ? 'success' : 'danger' }} mr-2">{{ $status ? 'OK' : 'Missing' }}</span>
+                <span>{{ $label }}</span>
+              </li>
+            @endforeach
+          </ul>
+          <hr>
+          <p class="mb-1"><strong>Database connection</strong></p>
+          @if($databaseReady)
+            <span class="badge badge-success">Connected</span>
+            <small class="d-block text-muted">Migrations will run automatically.</small>
+          @else
+            <span class="badge badge-danger">Not connected</span>
+            <small class="d-block text-muted">Update your .env database credentials, then refresh.</small>
+          @endif
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-8">
+      <div class="card shadow-sm">
+        <div class="card-header">Initial Configuration</div>
+        <div class="card-body">
+          <p class="text-muted">Set the brand details and administrator account for your billing portal.</p>
+          @if($errors->any())
+            <div class="alert alert-danger">
+              <strong>We found some issues:</strong>
+              <ul class="mb-0">
+                @foreach($errors->all() as $error)
+                  <li>{{ $error }}</li>
+                @endforeach
+              </ul>
+            </div>
+          @endif
+          <form method="POST" action="{{ route('install.store') }}">
+            @csrf
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="app_name">Portal Name</label>
+                <input type="text" class="form-control" id="app_name" name="app_name" value="{{ old('app_name', $defaultAppName) }}" required>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="app_url">Portal URL</label>
+                <input type="url" class="form-control" id="app_url" name="app_url" value="{{ old('app_url', $defaultUrl) }}" required>
+              </div>
+            </div>
+
+            <hr>
+            <h5 class="mt-3">Administrator Account</h5>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="admin_name">Full Name</label>
+                <input type="text" class="form-control" id="admin_name" name="admin_name" value="{{ old('admin_name') }}" required>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="admin_email">Email</label>
+                <input type="email" class="form-control" id="admin_email" name="admin_email" value="{{ old('admin_email') }}" required>
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="admin_password">Password</label>
+                <input type="password" class="form-control" id="admin_password" name="admin_password" required>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="admin_password_confirmation">Confirm Password</label>
+                <input type="password" class="form-control" id="admin_password_confirmation" name="admin_password_confirmation" required>
+              </div>
+            </div>
+
+            <hr>
+            <h5 class="mt-3">Company Details</h5>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="company_name">Company Name</label>
+                <input type="text" class="form-control" id="company_name" name="company_name" value="{{ old('company_name') }}" required>
+              </div>
+              <div class="form-group col-md-6">
+                <label for="company_email">Billing Email</label>
+                <input type="email" class="form-control" id="company_email" name="company_email" value="{{ old('company_email') }}" required>
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-6">
+                <label for="company_phone">Phone</label>
+                <input type="text" class="form-control" id="company_phone" name="company_phone" value="{{ old('company_phone') }}">
+              </div>
+              <div class="form-group col-md-6">
+                <label for="company_tax_id">Tax ID</label>
+                <input type="text" class="form-control" id="company_tax_id" name="company_tax_id" value="{{ old('company_tax_id') }}">
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="company_address">Address</label>
+              <textarea class="form-control" id="company_address" name="company_address" rows="3">{{ old('company_address') }}</textarea>
+            </div>
+            <div class="form-row">
+              <div class="form-group col-md-4">
+                <label for="currency">Billing Currency</label>
+                <input type="text" class="form-control text-uppercase" id="currency" name="currency" maxlength="3" value="{{ old('currency', 'IDR') }}" required>
+                <small class="text-muted">Use ISO currency code (e.g. IDR, USD).</small>
+              </div>
+              <div class="form-group col-md-4">
+                <label for="tax_rate">Default Tax Rate (%)</label>
+                <input type="number" step="0.01" min="0" class="form-control" id="tax_rate" name="tax_rate" value="{{ old('tax_rate', 0) }}">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="manual_instructions">Manual Payment Instructions</label>
+              <textarea class="form-control" id="manual_instructions" name="manual_instructions" rows="4" placeholder="Describe bank transfer instructions">{{ old('manual_instructions') }}</textarea>
+              <small class="text-muted">Displayed when customers select manual/transfer payment.</small>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center">
+              <div class="text-muted">By continuing, migrations will run and the administrator will be created.</div>
+              <button type="submit" class="btn btn-primary btn-lg">Complete Installation</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/invoices/index.blade.php
+++ b/resources/views/invoices/index.blade.php
@@ -20,7 +20,14 @@
           @foreach($invoices as $inv)
             <tr>
               <td>{{ $inv->number }}</td>
-              <td><span class="badge badge-{{ $inv->status==='paid'?'success':($inv->status==='unpaid'?'warning':'secondary') }}">{{ ucfirst($inv->status) }}</span></td>
+              @php
+                $badge = [
+                  'paid' => 'success',
+                  'unpaid' => 'warning',
+                  'overdue' => 'danger',
+                ][$inv->status] ?? 'secondary';
+              @endphp
+              <td><span class="badge badge-{{ $badge }}">{{ ucfirst($inv->status) }}</span></td>
               <td>{{ number_format($inv->total,0) }} {{ $inv->currency }}</td>
               <td>{{ optional($inv->due_date)->format('Y-m-d') }}</td>
               <td class="text-right"><a href="{{ url('/invoices/'.$inv->id) }}" class="btn btn-sm btn-primary">View</a></td>

--- a/resources/views/invoices/show.blade.php
+++ b/resources/views/invoices/show.blade.php
@@ -1,6 +1,18 @@
 @extends('layouts.app')
 @section('content')
 <div class="container">
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  @if($errors->any())
+    <div class="alert alert-danger">
+      <ul class="mb-0">
+        @foreach($errors->all() as $error)
+          <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+  @endif
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h3 class="mb-0">Invoice {{ $invoice->number }}</h3>
     <div>
@@ -11,10 +23,22 @@
 
   <div class="row">
     <div class="col-md-8">
+      @php
+        $balanceDue = $invoice->balanceDue();
+        $creditBalance = optional($invoice->client)->credit_balance ?? 0;
+      @endphp
       <div class="card mb-3">
         <div class="card-body">
-          <div class="mb-2"><strong>Status:</strong> <span class="badge badge-{{ $invoice->status==='paid'?'success':($invoice->status==='unpaid'?'warning':'secondary') }}">{{ ucfirst($invoice->status) }}</span></div>
+          @php
+            $badge = [
+              'paid' => 'success',
+              'unpaid' => 'warning',
+              'overdue' => 'danger',
+            ][$invoice->status] ?? 'secondary';
+          @endphp
+          <div class="mb-2"><strong>Status:</strong> <span class="badge badge-{{ $badge }}">{{ ucfirst($invoice->status) }}</span></div>
           <div class="mb-2"><strong>Total:</strong> {{ number_format($invoice->total,0) }} {{ $invoice->currency }}</div>
+          <div class="mb-2"><strong>Balance Due:</strong> {{ number_format($balanceDue,2) }} {{ $invoice->currency }}</div>
           <div class="mb-3"><strong>Due:</strong> {{ optional($invoice->due_date)->format('Y-m-d') }}</div>
 
           <div class="table-responsive">
@@ -34,28 +58,78 @@
           </div>
         </div>
       </div>
-    </div>
-    <div class="col-md-4">
-      @if($invoice->status !== 'paid')
-      <div class="card">
-        <div class="card-header">Pay Invoice</div>
-        <div class="card-body">
-          <div class="form-group">
-            <label>Gateway</label>
-            <select id="gateway" class="form-control">
-              @foreach($gateways as $gw)
-                <option value="{{ $gw['key'] }}">{{ $gw['name'] }}</option>
-              @endforeach
-            </select>
-          </div>
-          <button id="payBtn" class="btn btn-primary btn-block">Pay Now</button>
-          <small class="text-muted d-block mt-2" id="payMsg"></small>
-          <div class="mt-2 d-none" id="instrWrap">
-            <pre class="mb-2" id="payInstructions" style="white-space:pre-wrap"></pre>
-            <button class="btn btn-light btn-sm" id="copyInstrBtn">Copy Instructions</button>
+      @if($invoice->payments->isNotEmpty())
+        <div class="card mb-3">
+          <div class="card-header">Payment History</div>
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table table-sm mb-0">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Gateway</th>
+                    <th class="text-right">Amount</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                @foreach($invoice->payments->sortBy('created_at') as $payment)
+                  <tr>
+                    <td>{{ optional($payment->paid_at ?? $payment->created_at)->format('Y-m-d H:i') }}</td>
+                    <td>{{ ucfirst($payment->gateway) }}</td>
+                    <td class="text-right">{{ number_format($payment->amount,0) }} {{ $invoice->currency }}</td>
+                    <td><span class="badge badge-{{ $payment->status === 'completed' ? 'success' : ($payment->status === 'pending' ? 'warning' : 'secondary') }}">{{ ucfirst(str_replace('_',' ',$payment->status)) }}</span></td>
+                  </tr>
+                @endforeach
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
-      </div>
+      @endif
+    </div>
+    <div class="col-md-4">
+      @if($balanceDue > 0 && $creditBalance > 0)
+        <div class="card mb-3">
+          <div class="card-header">Use Account Credit</div>
+          <div class="card-body">
+            <p class="mb-2">Available credit: <strong>{{ number_format($creditBalance,0) }} {{ $invoice->currency }}</strong></p>
+            <form method="POST" action="{{ url('/invoices/'.$invoice->id.'/apply-credit') }}">
+              @csrf
+              <div class="form-group">
+                <label>Amount to apply</label>
+                <input type="number" name="amount" min="0" step="0.01" max="{{ number_format(min($creditBalance,$balanceDue),2,'.','') }}" value="{{ old('amount') }}" class="form-control" placeholder="{{ number_format(min($creditBalance,$balanceDue),2,'.','') }}">
+                <small class="form-text text-muted">Leave empty to apply the maximum available credit.</small>
+              </div>
+              <button class="btn btn-outline-primary btn-block" type="submit">Apply Credit</button>
+            </form>
+          </div>
+        </div>
+      @endif
+      @if($invoice->status !== 'paid' && $balanceDue > 0)
+        @if(empty($gateways))
+          <div class="alert alert-warning">Tidak ada gateway pembayaran yang aktif. Silakan hubungi admin.</div>
+        @else
+        <div class="card">
+          <div class="card-header">Pay Invoice</div>
+          <div class="card-body">
+            <div class="form-group">
+              <label>Gateway</label>
+              <select id="gateway" class="form-control">
+                @foreach($gateways as $gw)
+                  <option value="{{ $gw['key'] }}">{{ $gw['name'] }}</option>
+                @endforeach
+              </select>
+            </div>
+            <button id="payBtn" class="btn btn-primary btn-block">Pay Now</button>
+            <small class="text-muted d-block mt-2" id="payMsg"></small>
+            <div class="mt-2 d-none" id="instrWrap">
+              <pre class="mb-2" id="payInstructions" style="white-space:pre-wrap"></pre>
+              <button class="btn btn-light btn-sm" id="copyInstrBtn">Copy Instructions</button>
+            </div>
+          </div>
+        </div>
+        @endif
       @else
         <div class="alert alert-success">Thank you, this invoice is paid.</div>
       @endif

--- a/resources/views/services/index.blade.php
+++ b/resources/views/services/index.blade.php
@@ -5,19 +5,62 @@
     <h3 class="mb-0">My Services</h3>
     <a href="{{ url('/shop') }}" class="btn btn-sm btn-outline-primary">Order More</a>
   </div>
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  @if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+  @endif
   @if($services->isEmpty())
     <div class="alert alert-info">No active services yet.</div>
   @else
     <div class="table-responsive">
       <table class="table table-hover">
-        <thead><tr><th>ID</th><th>Product</th><th>Status</th><th>Created</th></tr></thead>
+        <thead><tr><th>ID</th><th>Product</th><th>Status</th><th>Next Due</th><th>Access</th><th class="text-right">Actions</th></tr></thead>
         <tbody>
           @foreach($services as $s)
+            @php
+              $badge = [
+                'active' => 'success',
+                'pending' => 'warning',
+                'suspended' => 'danger',
+                'terminated' => 'secondary',
+              ][$s->status] ?? 'secondary';
+              $meta = $s->meta ?? [];
+              $canOperate = $s->status === 'active';
+              $disabledAttr = $canOperate ? '' : 'disabled';
+            @endphp
             <tr>
               <td>#{{ $s->id }}</td>
               <td>{{ optional($s->product)->name }}</td>
-              <td><span class="badge badge-{{ $s->status==='active'?'success':($s->status==='pending'?'warning':'secondary') }}">{{ ucfirst($s->status) }}</span></td>
-              <td>{{ optional($s->created_at)->format('Y-m-d') }}</td>
+              <td><span class="badge badge-{{ $badge }}">{{ ucfirst($s->status) }}</span><br><small class="text-muted">Created {{ optional($s->created_at)->format('Y-m-d') }}</small></td>
+              <td>{{ optional($s->next_due_date)->format('Y-m-d') }}</td>
+              <td>
+                <div><strong>IP:</strong> {{ $meta['ip'] ?? 'n/a' }}</div>
+                <div><strong>Password:</strong> {{ $meta['password'] ?? 'n/a' }}</div>
+              </td>
+              <td class="text-right" style="min-width:220px;">
+                <form method="POST" action="{{ url('/services/'.$s->id.'/actions/reboot') }}" class="d-inline">
+                  @csrf
+                  <button class="btn btn-outline-secondary btn-sm mb-1" {{ $disabledAttr }}>Reboot</button>
+                </form>
+                <form method="POST" action="{{ url('/services/'.$s->id.'/actions/power-off') }}" class="d-inline">
+                  @csrf
+                  <button class="btn btn-outline-secondary btn-sm mb-1" {{ $disabledAttr }}>Power Off</button>
+                </form>
+                <form method="POST" action="{{ url('/services/'.$s->id.'/actions/power-on') }}" class="d-inline">
+                  @csrf
+                  <button class="btn btn-outline-secondary btn-sm mb-1" {{ $disabledAttr }}>Power On</button>
+                </form>
+                <form method="POST" action="{{ url('/services/'.$s->id.'/actions/reset-password') }}" class="d-inline">
+                  @csrf
+                  <button class="btn btn-outline-primary btn-sm mb-1" {{ $disabledAttr }}>Reset Password</button>
+                </form>
+                <a href="{{ url('/services/'.$s->id.'/actions/console') }}"
+                   class="btn btn-outline-info btn-sm mb-1 {{ $canOperate ? '' : 'disabled' }}"
+                   target="_blank"
+                   @if(! $canOperate) tabindex="-1" aria-disabled="true" onclick="return false;" @endif>Open Console</a>
+              </td>
             </tr>
           @endforeach
         </tbody>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+@section('content')
+<div class="container" style="max-width: 720px;">
+  <h3 class="mb-3">Create Support Ticket</h3>
+  <div class="card">
+    <div class="card-body">
+      <form method="POST" action="{{ route('tickets.store') }}">
+        @csrf
+        <div class="form-group">
+          <label>Subject</label>
+          <input type="text" class="form-control @error('subject') is-invalid @enderror" name="subject" value="{{ old('subject') }}" required maxlength="150">
+          @error('subject')<div class="invalid-feedback">{{ $message }}</div>@enderror
+        </div>
+        <div class="form-row">
+          <div class="form-group col-md-6">
+            <label>Department</label>
+            <input type="text" class="form-control @error('department') is-invalid @enderror" name="department" value="{{ old('department') }}" placeholder="Billing, Support, Sales...">
+            @error('department')<div class="invalid-feedback">{{ $message }}</div>@enderror
+          </div>
+          <div class="form-group col-md-6">
+            <label>Priority</label>
+            <select class="form-control @error('priority') is-invalid @enderror" name="priority" required>
+              @foreach(['low'=>'Low','normal'=>'Normal','high'=>'High'] as $value => $label)
+                <option value="{{ $value }}" {{ old('priority','normal')===$value?'selected':'' }}>{{ $label }}</option>
+              @endforeach
+            </select>
+            @error('priority')<div class="invalid-feedback">{{ $message }}</div>@enderror
+          </div>
+        </div>
+        <div class="form-group">
+          <label>Message</label>
+          <textarea class="form-control @error('message') is-invalid @enderror" rows="8" name="message" required>{{ old('message') }}</textarea>
+          @error('message')<div class="invalid-feedback">{{ $message }}</div>@enderror
+        </div>
+        <div class="text-right">
+          <button class="btn btn-primary">Submit Ticket</button>
+          <a href="{{ route('tickets.index') }}" class="btn btn-link">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+@section('content')
+<div class="container" style="max-width: 960px;">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3 class="mb-0">Support Tickets</h3>
+    <a href="{{ route('tickets.create') }}" class="btn btn-primary">New Ticket</a>
+  </div>
+  <div class="card">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>Reference</th>
+              <th>Subject</th>
+              <th>Status</th>
+              <th>Priority</th>
+              <th class="text-right">Last Update</th>
+            </tr>
+          </thead>
+          <tbody>
+            @forelse($tickets as $ticket)
+              <tr onclick="window.location='{{ route('tickets.show', $ticket) }}'" style="cursor:pointer;">
+                <td>{{ $ticket->reference }}</td>
+                <td>{{ $ticket->subject }}</td>
+                <td>
+                  @php
+                    $statusColor = [
+                      'open' => 'warning',
+                      'answered' => 'info',
+                      'closed' => 'secondary',
+                    ][$ticket->status] ?? 'secondary';
+                  @endphp
+                  <span class="badge badge-{{ $statusColor }}">{{ ucfirst($ticket->status) }}</span>
+                </td>
+                <td>{{ ucfirst($ticket->priority) }}</td>
+                <td class="text-right">{{ optional($ticket->updated_at)->diffForHumans() }}</td>
+              </tr>
+            @empty
+              <tr>
+                <td colspan="5" class="text-center p-4 text-muted">You do not have any support tickets yet.</td>
+              </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+    </div>
+    @if($tickets instanceof \Illuminate\Contracts\Pagination\Paginator)
+      <div class="card-footer">{{ $tickets->links() }}</div>
+    @endif
+  </div>
+</div>
+@endsection

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.app')
+@section('content')
+<div class="container" style="max-width: 860px;">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h3 class="mb-0">Ticket {{ $ticket->reference }}</h3>
+      <small class="text-muted">Subject: {{ $ticket->subject }}</small>
+    </div>
+    <div>
+      <a href="{{ route('tickets.index') }}" class="btn btn-link">Back</a>
+      @if($ticket->status !== 'closed')
+        <form method="POST" action="{{ route('tickets.close', $ticket) }}" class="d-inline">
+          @csrf
+          <button class="btn btn-outline-secondary btn-sm" type="submit">Close Ticket</button>
+        </form>
+      @endif
+    </div>
+  </div>
+  @if(session('status'))
+    <div class="alert alert-success">{{ session('status') }}</div>
+  @endif
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="d-flex justify-content-between">
+        <div>
+          <div><strong>Status:</strong> <span class="badge badge-{{ $ticket->status==='closed'?'secondary':($ticket->status==='answered'?'info':'warning') }}">{{ ucfirst($ticket->status) }}</span></div>
+          <div><strong>Priority:</strong> {{ ucfirst($ticket->priority) }}</div>
+          @if($ticket->department)
+          <div><strong>Department:</strong> {{ $ticket->department }}</div>
+          @endif
+        </div>
+        <div class="text-right text-muted">
+          <div>Opened {{ optional($ticket->created_at)->format('Y-m-d H:i') }}</div>
+          <div>Updated {{ optional($ticket->updated_at)->diffForHumans() }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="timeline">
+    @foreach($ticket->replies as $reply)
+      <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <div>
+            <strong>{{ $reply->user && $reply->user->id === auth()->id() ? 'You' : optional($reply->user)->name ?? 'Support' }}</strong>
+            <small class="text-muted ml-2">{{ optional($reply->created_at)->format('Y-m-d H:i') }}</small>
+            @if($reply->is_internal)
+              <span class="badge badge-secondary ml-2">Internal</span>
+            @endif
+          </div>
+        </div>
+        <div class="card-body">
+          <pre class="mb-0" style="white-space: pre-wrap;">{{ $reply->message }}</pre>
+        </div>
+      </div>
+    @endforeach
+  </div>
+
+  @if($ticket->status !== 'closed')
+    <div class="card">
+      <div class="card-header">Reply to Ticket</div>
+      <div class="card-body">
+        <form method="POST" action="{{ route('tickets.reply', $ticket) }}">
+          @csrf
+          <div class="form-group">
+            <textarea name="message" rows="6" class="form-control @error('message') is-invalid @enderror" placeholder="Write your response..." required>{{ old('message') }}</textarea>
+            @error('message')<div class="invalid-feedback">{{ $message }}</div>@enderror
+          </div>
+          <div class="text-right">
+            <button class="btn btn-primary">Send Reply</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  @else
+    <div class="alert alert-secondary">This ticket is closed. Re-open it by contacting support if needed.</div>
+  @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,16 +1,24 @@
 <?php
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
-use App\Domain\Payments\GatewayManager;
-use App\Domain\Provisioning\ProvisioningManager;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\PaymentWebhookController;
 use App\Http\Controllers\ShopController;
 use App\Http\Controllers\InvoicesController;
+use App\Http\Controllers\InvoiceCreditController;
 use App\Http\Controllers\ServiceController;
+use App\Http\Controllers\ServiceActionsController;
 use App\Http\Controllers\AdminSettingsController;
+use App\Http\Controllers\AdminPaymentsController;
 use App\Http\Controllers\InvoicePdfController;
 use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\AdminDashboardController;
+use App\Http\Controllers\InstallController;
+use App\Http\Controllers\TicketController;
+use App\Http\Controllers\AdminTicketController;
+use App\Http\Controllers\AdminClientController;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,23 +31,59 @@ use App\Http\Controllers\PaymentController;
 |
 */
 
+Route::get('/health', fn () => response()->json(['status' => 'ok']));
+
+Route::get('/install', [InstallController::class, 'index'])->name('install.index');
+Route::post('/install', [InstallController::class, 'store'])->name('install.store');
+
 Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/health', fn()=>response()->json(['status'=>'ok']));
 Route::get('/shop', [ShopController::class, 'index']);
 
 Route::middleware(['auth','verified'])->group(function(){
     Route::get('/plans',[OrderController::class,'plans']);
     Route::post('/orders',[OrderController::class,'create']);
-    Route::post('/pay/{gateway}/{invoice}',[PaymentController::class,'initiate']);
+    Route::post('/pay/{gateway}/{invoice}',[PaymentController::class,'initiate'])->middleware('throttle:10,1');
     Route::get('/invoices',[InvoicesController::class,'index']);
     Route::get('/invoices/{invoice}',[InvoicesController::class,'show']);
+    Route::post('/invoices/{invoice}/apply-credit',[InvoiceCreditController::class,'apply'])->name('invoices.apply-credit');
+    Route::get('/tickets',[TicketController::class,'index'])->name('tickets.index');
+    Route::get('/tickets/create',[TicketController::class,'create'])->name('tickets.create');
+    Route::post('/tickets',[TicketController::class,'store'])->name('tickets.store');
+    Route::get('/tickets/{ticket}',[TicketController::class,'show'])->name('tickets.show');
+    Route::post('/tickets/{ticket}/reply',[TicketController::class,'reply'])->name('tickets.reply');
+    Route::post('/tickets/{ticket}/close',[TicketController::class,'close'])->name('tickets.close');
     Route::get('/services',[ServiceController::class,'index']);
+    Route::post('/services/{service}/actions/reboot',[ServiceActionsController::class,'reboot']);
+    Route::post('/services/{service}/actions/power-on',[ServiceActionsController::class,'powerOn']);
+    Route::post('/services/{service}/actions/power-off',[ServiceActionsController::class,'powerOff']);
+    Route::post('/services/{service}/actions/reset-password',[ServiceActionsController::class,'resetPassword']);
+    Route::get('/services/{service}/actions/console',[ServiceActionsController::class,'console']);
     Route::get('/invoices/{invoice}/pdf',[InvoicePdfController::class,'show']);
-    Route::get('/admin/settings',[AdminSettingsController::class,'show']);
-    Route::post('/admin/settings',[AdminSettingsController::class,'update']);
+
+    Route::prefix('admin')->name('admin.')->middleware('admin')->group(function(){
+        Route::get('/dashboard',[AdminDashboardController::class,'index'])->name('dashboard');
+        Route::get('/settings',[AdminSettingsController::class,'show'])->name('settings.show');
+        Route::post('/settings',[AdminSettingsController::class,'update'])->name('settings.update');
+        Route::get('/payments',[AdminPaymentsController::class,'index'])->name('payments.index');
+        Route::post('/payments/{payment}/confirm',[AdminPaymentsController::class,'confirm'])->name('payments.confirm');
+        Route::get('/clients',[AdminClientController::class,'index'])->name('clients.index');
+        Route::get('/clients/{client}',[AdminClientController::class,'show'])->name('clients.show');
+        Route::post('/clients/{client}/credit',[AdminClientController::class,'adjustCredit'])->name('clients.credit');
+        Route::get('/tickets',[AdminTicketController::class,'index'])->name('tickets.index');
+        Route::get('/tickets/{ticket}',[AdminTicketController::class,'show'])->name('tickets.show');
+        Route::post('/tickets/{ticket}/reply',[AdminTicketController::class,'reply'])->name('tickets.reply');
+        Route::post('/tickets/{ticket}/status',[AdminTicketController::class,'updateStatus'])->name('tickets.status');
+    });
 });
 
 Route::post('/webhook/payments/{gateway}',[PaymentWebhookController::class,'handle']);
+
+Route::post('/logout', function (Request $request) {
+    Auth::guard()->logout();
+    $request->session()->invalidate();
+    $request->session()->regenerateToken();
+    return redirect('/');
+})->middleware('auth')->name('logout');

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,6 +17,15 @@ trait CreatesApplication
 
         $app->make(Kernel::class)->bootstrap();
 
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
+
         return $app;
     }
 }

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Product;
+use App\Models\Service;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_dashboard_with_metrics(): void
+    {
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => now(),
+        ]);
+
+        $clientUser = User::factory()->create(['email_verified_at' => now()]);
+        $client = Client::create(['user_id' => $clientUser->id]);
+        $product = Product::create([
+            'name' => 'VPS Basic',
+            'slug' => 'vps-basic',
+            'description' => 'Starter plan',
+            'base_price' => 150000,
+            'currency' => 'IDR',
+            'options' => ['cpu' => 1],
+            'is_active' => true,
+        ]);
+        Service::create([
+            'client_id' => $client->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'billing_cycle' => 'monthly',
+            'next_due_date' => Carbon::now()->addDays(5),
+            'meta' => ['driver' => 'virtfusion'],
+        ]);
+
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'paid',
+            'subtotal' => 150000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'total' => 150000,
+            'tax_rate' => 0,
+            'currency' => 'IDR',
+            'due_date' => Carbon::now()->addDays(5),
+            'paid_at' => Carbon::now(),
+        ]);
+
+        Payment::create([
+            'invoice_id' => $invoice->id,
+            'gateway' => 'manual',
+            'amount' => 150000,
+            'currency' => 'IDR',
+            'status' => 'pending',
+        ]);
+
+        $this->actingAs($admin)->get('/admin/dashboard')
+            ->assertStatus(200)
+            ->assertSee('Admin Dashboard')
+            ->assertSee('Active Services')
+            ->assertSee('Revenue (last 6 months)')
+            ->assertSee('Upcoming Renewals');
+    }
+
+    public function test_non_admin_is_denied(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now(), 'is_admin' => false]);
+
+        $this->actingAs($user)->get('/admin/dashboard')->assertStatus(403);
+    }
+}

--- a/tests/Feature/AdminSettingsTest.php
+++ b/tests/Feature/AdminSettingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\Settings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_manual_instructions_can_be_cleared(): void
+    {
+        Settings::set('payments.manual.instructions', 'Transfer to account');
+
+        $admin = User::factory()->create([
+            'is_admin' => true,
+            'email_verified_at' => now(),
+        ]);
+
+        $payload = [
+            'branding_name' => 'Test Billing',
+            'manual_instructions' => '',
+            'company_name' => 'Test Company',
+            'company_address' => '123 Road',
+            'company_tax_id' => '123',
+            'company_email' => 'billing@example.com',
+            'company_phone' => '080000',
+            'company_logo_url' => 'https://example.com/logo.png',
+            'finance_tax_rate' => '',
+            'invoice_number_prefix' => 'INV',
+            'invoice_number_date_format' => 'Ymd',
+            'invoice_sequence_scope' => 'global',
+            'invoice_footer' => 'Thanks',
+        ];
+
+        $this->actingAs($admin)->post('/admin/settings', $payload)->assertRedirect();
+
+        $this->assertSame('', Settings::get('payments.manual.instructions'));
+        $this->assertSame(0.0, Settings::get('finance.tax_rate'));
+    }
+}

--- a/tests/Feature/BillingRenewalsCommandTest.php
+++ b/tests/Feature/BillingRenewalsCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SuspendServiceJob;
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\Product;
+use App\Models\Service;
+use App\Models\User;
+use App\Support\Settings;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class BillingRenewalsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_overdue_invoice_triggers_suspension_once_and_updates_meta(): void
+    {
+        Queue::fake();
+        Carbon::setTestNow('2025-01-10 00:00:00');
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $client = Client::create(['user_id' => $user->id]);
+        $product = Product::create([
+            'name' => 'Cloud VPS',
+            'slug' => 'cloud-vps',
+            'base_price' => 150000,
+            'currency' => 'IDR',
+            'is_active' => true,
+        ]);
+        $service = Service::create([
+            'client_id' => $client->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'billing_cycle' => 'monthly',
+            'next_due_date' => Carbon::now()->addMonth(),
+            'meta' => [],
+        ]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'overdue',
+            'subtotal' => 150000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 150000,
+            'currency' => 'IDR',
+            'due_date' => Carbon::now()->subDays(3),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'service_id' => $service->id,
+            'description' => 'Renewal',
+            'quantity' => 1,
+            'unit_price' => 150000,
+            'discount' => 0,
+            'total' => 150000,
+        ]);
+
+        Settings::set('finance.suspension_grace_days', 0, 'int');
+
+        Artisan::call('billing:renewals');
+
+        Queue::assertPushed(SuspendServiceJob::class, function (SuspendServiceJob $job) use ($service) {
+            return $job->serviceId === $service->id;
+        });
+        Queue::assertPushed(SuspendServiceJob::class, 1);
+
+        $this->assertNotNull($service->fresh()->meta['suspension_requested_at'] ?? null);
+        $this->assertEquals('overdue', $invoice->fresh()->status);
+
+        Carbon::setTestNow('2025-01-10 01:00:00');
+        Artisan::call('billing:renewals');
+        Queue::assertPushed(SuspendServiceJob::class, 1);
+    }
+}

--- a/tests/Feature/CreditBalanceTest.php
+++ b/tests/Feature/CreditBalanceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\Product;
+use App\Models\User;
+use App\Support\CreditManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreditBalanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function createInvoice(User $user, float $total): Invoice
+    {
+        $client = Client::create(['user_id' => $user->id, 'credit_balance' => 0]);
+        $product = Product::create([
+            'name' => 'Dedicated Server',
+            'slug' => 'dedicated',
+            'base_price' => $total,
+            'currency' => 'IDR',
+            'is_active' => true,
+        ]);
+
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => $total,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => $total,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'product_id' => $product->id,
+            'service_id' => null,
+            'description' => 'Service',
+            'quantity' => 1,
+            'unit_price' => $total,
+            'discount' => 0,
+            'total' => $total,
+        ]);
+
+        return $invoice->fresh(['client']);
+    }
+
+    public function test_credit_can_fully_pay_invoice(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $invoice = $this->createInvoice($user, 200000);
+        CreditManager::addCredit($invoice->client, 250000, 'Initial credit', $user->id);
+
+        $response = $this->actingAs($user)->post(route('invoices.apply-credit', $invoice));
+        $response->assertRedirect();
+
+        $invoice->refresh();
+        $this->assertEquals('paid', $invoice->status);
+        $this->assertEquals(50000.00, $invoice->client->fresh()->credit_balance);
+        $this->assertDatabaseHas('payments', [
+            'invoice_id' => $invoice->id,
+            'gateway' => 'credit',
+            'status' => 'completed',
+            'amount' => 200000.00,
+        ]);
+    }
+
+    public function test_partial_credit_reduces_balance_due(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $invoice = $this->createInvoice($user, 150000);
+        CreditManager::addCredit($invoice->client, 50000, 'Partial credit', $user->id);
+
+        $this->actingAs($user)->post(route('invoices.apply-credit', $invoice))->assertRedirect();
+
+        $invoice->refresh();
+        $this->assertEquals('unpaid', $invoice->status);
+        $this->assertEquals(0.0, $invoice->client->fresh()->credit_balance);
+        $this->assertEquals(100000.00, $invoice->balanceDue());
+        $this->assertDatabaseHas('payments', [
+            'invoice_id' => $invoice->id,
+            'gateway' => 'credit',
+            'amount' => 50000.00,
+        ]);
+    }
+}

--- a/tests/Feature/InstallationTest.php
+++ b/tests/Feature/InstallationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\EnvWriter;
+use App\Support\Settings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class InstallationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['app.installed' => false]);
+    }
+
+    protected function tearDown(): void
+    {
+        EnvWriter::usePath(null);
+        parent::tearDown();
+    }
+
+    public function test_installation_wizard_creates_admin_and_marks_app_installed(): void
+    {
+        $tempEnv = base_path('tests/temp_install.env');
+        if (file_exists($tempEnv)) {
+            unlink($tempEnv);
+        }
+        EnvWriter::usePath($tempEnv);
+
+        $this->get('/install')->assertStatus(200)->assertSee('Initial Configuration');
+
+        $response = $this->post('/install', [
+            'app_name' => 'My Billing Suite',
+            'app_url' => 'https://billing.test',
+            'admin_name' => 'Super Admin',
+            'admin_email' => 'admin@example.com',
+            'admin_password' => 'secret1234',
+            'admin_password_confirmation' => 'secret1234',
+            'company_name' => 'Acme Hosting',
+            'company_email' => 'finance@acme.test',
+            'company_phone' => '+62 8123456789',
+            'company_address' => 'Jl. Kebon Jeruk No. 42',
+            'company_tax_id' => 'NPWP-123',
+            'currency' => 'IDR',
+            'tax_rate' => '11',
+            'manual_instructions' => 'Transfer ke Bank BCA 123456789 a.n ACME.',
+        ]);
+
+        $response->assertRedirect(route('admin.dashboard'));
+
+        $admin = User::where('email', 'admin@example.com')->first();
+        $this->assertNotNull($admin);
+        $this->assertTrue($admin->is_admin);
+        $this->assertNotNull($admin->email_verified_at);
+        $this->assertTrue(Hash::check('secret1234', $admin->password));
+
+        $this->assertEquals('My Billing Suite', Settings::get('branding.name'));
+        $this->assertEquals('Acme Hosting', Settings::get('company.name'));
+        $this->assertEquals('IDR', Settings::get('company.currency'));
+        $this->assertEquals(['manual'], Settings::get('payments.enabled'));
+        $this->assertEquals(11.0, Settings::get('finance.tax_rate'));
+
+        $envContent = file_get_contents($tempEnv);
+        $this->assertStringContainsString('APP_INSTALLED=true', $envContent);
+        $this->assertStringContainsString('APP_NAME="My Billing Suite"', $envContent);
+        if (file_exists($tempEnv)) {
+            unlink($tempEnv);
+        }
+
+        config(['app.installed' => true]);
+    }
+}

--- a/tests/Feature/LoginActivityTest.php
+++ b/tests/Feature/LoginActivityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LoginActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_logout_and_failed_events_are_recorded(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        event(new Login('web', $user, false));
+        event(new Logout('web', $user));
+        event(new Failed('web', $user, ['email' => $user->email]));
+
+        $this->assertDatabaseHas('login_activities', [
+            'user_id' => $user->id,
+            'event' => 'login',
+        ]);
+        $this->assertDatabaseHas('login_activities', [
+            'user_id' => $user->id,
+            'event' => 'logout',
+        ]);
+        $this->assertDatabaseHas('login_activities', [
+            'event' => 'failed',
+            'identifier' => $user->email,
+        ]);
+    }
+}

--- a/tests/Feature/OrderControllerTest.php
+++ b/tests/Feature/OrderControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_inactive_product_cannot_be_ordered(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $product = Product::create([
+            'name' => 'Legacy Plan',
+            'slug' => 'legacy-plan',
+            'description' => 'Old plan',
+            'base_price' => 120000,
+            'currency' => 'IDR',
+            'options' => [],
+            'is_active' => false,
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/orders', [
+            'product_id' => $product->id,
+            'billing_cycle' => 'monthly',
+        ]);
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/PaymentControllerTest.php
+++ b/tests/Feature/PaymentControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Payments\Contracts\PaymentGateway;
+use App\Domain\Payments\GatewayManager;
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class PaymentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refreshGatewayManager();
+    }
+
+    protected function refreshGatewayManager(): void
+    {
+        app()->singleton(GatewayManager::class, function () {
+            return new GatewayManager();
+        });
+    }
+
+    public function test_gateway_errors_are_sanitized(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $client = Client::create(['user_id' => $user->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 150000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 150000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Hosting',
+            'quantity' => 1,
+            'unit_price' => 150000,
+            'discount' => 0,
+            'total' => 150000,
+        ]);
+
+        $gateway = new class implements PaymentGateway {
+            public function key(): string { return 'faulty'; }
+            public function displayName(): string { return 'Faulty Gateway'; }
+            public function createPayment(Invoice $invoice, array $options = []): \App\Models\Payment
+            {
+                throw new RuntimeException('API outage: sensitive details');
+            }
+            public function handleWebhook(\Illuminate\Http\Request $request): void {}
+            public function isConfigured(): bool { return true; }
+        };
+        app(GatewayManager::class)->register($gateway);
+
+        $response = $this->actingAs($user)->postJson('/pay/faulty/'.$invoice->id, []);
+        $response->assertStatus(400);
+        $response->assertJson(['message' => 'Unable to create payment, please try again or contact support.']);
+    }
+}

--- a/tests/Feature/PaymentGatewayVisibilityTest.php
+++ b/tests/Feature/PaymentGatewayVisibilityTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Payments\GatewayManager;
+use App\Events\InvoicePaid;
+use App\Models\Client;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\Payment;
+use App\Models\Product;
+use App\Models\Service;
+use App\Models\User;
+use App\Support\Settings;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class PaymentGatewayVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function resetGateways(): void
+    {
+        app()->forgetInstance(GatewayManager::class);
+        if (method_exists(app(), 'forgetResolvedInstance')) {
+            app()->forgetResolvedInstance(GatewayManager::class);
+        }
+    }
+
+    protected function createUser(bool $admin = false): User
+    {
+        return User::factory()->create([
+            'email_verified_at' => now(),
+            'is_admin' => $admin,
+        ]);
+    }
+
+    public function test_invoice_page_shows_only_configured_gateways(): void
+    {
+        Settings::set('payments.manual.instructions', 'Transfer to account 123456 an. PT Contoh.');
+        Settings::set('payments.enabled', ['manual'], 'json');
+        config([
+            'midtrans.server_key' => null,
+            'midtrans.client_key' => null,
+            'xendit.api_key' => null,
+            'xendit.callback_token' => null,
+            'tripay.api_key' => null,
+            'tripay.private_key' => null,
+            'tripay.merchant_code' => null,
+            'duitku.merchant_code' => null,
+            'duitku.api_key' => null,
+            'stripe.secret' => null,
+            'stripe.public' => null,
+        ]);
+        $this->resetGateways();
+
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 100000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 100000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Test Item',
+            'quantity' => 1,
+            'unit_price' => 100000,
+            'discount' => 0,
+            'total' => 100000,
+        ]);
+
+        $response = $this->actingAs($user)->get('/invoices/'.$invoice->id);
+        $response->assertStatus(200);
+        $response->assertSee('Bank Transfer (Manual)');
+        $response->assertDontSee('Midtrans');
+        $response->assertDontSee('Xendit');
+        $response->assertDontSee('Tripay');
+        $response->assertDontSee('Duitku');
+        $response->assertDontSee('Stripe');
+    }
+
+    public function test_manual_gateway_hidden_when_instructions_missing(): void
+    {
+        Settings::set('payments.manual.instructions', '');
+        Settings::set('payments.enabled', ['manual'], 'json');
+        $this->resetGateways();
+
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 50000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 50000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Manual Test',
+            'quantity' => 1,
+            'unit_price' => 50000,
+            'discount' => 0,
+            'total' => 50000,
+        ]);
+
+        $response = $this->actingAs($user)->get('/invoices/'.$invoice->id);
+        $response->assertStatus(200);
+        $response->assertDontSee('Bank Transfer (Manual)');
+    }
+
+    public function test_manual_gateway_hidden_when_disabled_via_settings(): void
+    {
+        Settings::set('payments.manual.instructions', 'Transfer instructions available.');
+        Settings::set('payments.enabled', ['midtrans'], 'json');
+        $this->resetGateways();
+
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 75000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 75000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Manual Disabled Test',
+            'quantity' => 1,
+            'unit_price' => 75000,
+            'discount' => 0,
+            'total' => 75000,
+        ]);
+
+        $response = $this->actingAs($user)->get('/invoices/'.$invoice->id);
+        $response->assertStatus(200);
+        $response->assertDontSee('Bank Transfer (Manual)');
+    }
+
+    public function test_unconfigured_gateway_cannot_be_used(): void
+    {
+        config(['xendit.api_key' => null, 'xendit.callback_token' => null]);
+        $this->resetGateways();
+
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 100000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 100000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+
+        $response = $this->from('/invoices/'.$invoice->id)->actingAs($user)->postJson('/pay/xendit/'.$invoice->id, []);
+        $response->assertStatus(404);
+        $response->assertJson(['message' => 'Payment gateway unavailable']);
+    }
+
+    public function test_renewal_invoice_is_generated_and_service_due_date_moves_after_payment(): void
+    {
+        Carbon::setTestNow('2025-01-01 00:00:00');
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $product = Product::create([
+            'name' => 'VPS Small',
+            'slug' => 'vps-small',
+            'description' => 'Test plan',
+            'base_price' => 150000,
+            'currency' => 'IDR',
+            'options' => ['cpu' => 1],
+            'is_active' => true,
+        ]);
+        $service = Service::create([
+            'client_id' => $client->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'billing_cycle' => 'monthly',
+            'next_due_date' => Carbon::now()->addDays(2),
+            'meta' => ['driver' => 'virtfusion'],
+        ]);
+
+        $this->artisan('billing:renewals');
+        $invoice = Invoice::where('client_id', $client->id)->first();
+        $this->assertNotNull($invoice);
+        $this->assertEquals('unpaid', $invoice->status);
+        $this->assertEquals($service->next_due_date->format('Y-m-d'), optional($invoice->due_date)->format('Y-m-d'));
+        $this->assertCount(1, $invoice->items);
+        $this->assertEquals($service->id, $invoice->items->first()->service_id);
+
+        $this->artisan('billing:renewals');
+        $this->assertEquals(1, Invoice::where('client_id', $client->id)->count());
+
+        $invoice->refresh();
+        $invoice->status = 'paid';
+        $invoice->paid_at = Carbon::now();
+        $invoice->save();
+        event(new InvoicePaid($invoice));
+        $service->refresh();
+        $this->assertEquals('2025-02-03', optional($service->next_due_date)->format('Y-m-d'));
+        Carbon::setTestNow();
+    }
+
+    public function test_overdue_invoices_dispatch_suspend_job(): void
+    {
+        Carbon::setTestNow('2025-01-10 00:00:00');
+        Queue::fake();
+        $user = $this->createUser();
+        $client = Client::create(['user_id' => $user->id]);
+        $product = Product::create([
+            'name' => 'VPS Medium',
+            'slug' => 'vps-medium',
+            'description' => 'Plan',
+            'base_price' => 200000,
+            'currency' => 'IDR',
+            'options' => ['cpu' => 2],
+            'is_active' => true,
+        ]);
+        $service = Service::create([
+            'client_id' => $client->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'billing_cycle' => 'monthly',
+            'next_due_date' => Carbon::now()->addMonth(),
+            'meta' => ['driver' => 'virtfusion'],
+        ]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 200000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 200000,
+            'currency' => 'IDR',
+            'due_date' => Carbon::now()->subDays(5),
+        ]);
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'service_id' => $service->id,
+            'description' => 'Renewal',
+            'quantity' => 1,
+            'unit_price' => 200000,
+            'discount' => 0,
+            'total' => 200000,
+        ]);
+
+        $this->artisan('billing:renewals');
+        $invoice->refresh();
+        $this->assertEquals('overdue', $invoice->status);
+        Queue::assertPushed(\App\Jobs\SuspendServiceJob::class, function ($job) use ($service) {
+            return $job->serviceId === $service->id;
+        });
+        Carbon::setTestNow();
+    }
+
+    public function test_manual_payment_confirmation_marks_invoice_paid(): void
+    {
+        Event::fake([InvoicePaid::class]);
+        $admin = $this->createUser(true);
+        $client = Client::create(['user_id' => $admin->id]);
+        $invoice = Invoice::create([
+            'client_id' => $client->id,
+            'status' => 'unpaid',
+            'subtotal' => 50000,
+            'tax_total' => 0,
+            'discount_total' => 0,
+            'tax_rate' => 0,
+            'total' => 50000,
+            'currency' => 'IDR',
+            'due_date' => now()->addDay(),
+        ]);
+        $payment = Payment::create([
+            'invoice_id' => $invoice->id,
+            'gateway' => 'manual',
+            'amount' => 50000,
+            'currency' => 'IDR',
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($admin)->from('/admin/payments')->post('/admin/payments/'.$payment->id.'/confirm');
+        $response->assertRedirect('/admin/payments');
+        $response->assertSessionHas('status');
+
+        $this->assertEquals('completed', $payment->fresh()->status);
+        $this->assertEquals('paid', $invoice->fresh()->status);
+        Event::assertDispatched(InvoicePaid::class);
+        $this->assertDatabaseHas('payment_logs', [
+            'payment_id' => $payment->id,
+            'event' => 'manual_confirmed',
+        ]);
+    }
+}

--- a/tests/Feature/PaymentWebhookCsrfTest.php
+++ b/tests/Feature/PaymentWebhookCsrfTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Payments\Contracts\PaymentGateway;
+use App\Domain\Payments\GatewayManager;
+use App\Models\Invoice;
+use App\Models\Payment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class PaymentWebhookCsrfTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_webhook_bypasses_csrf_verification(): void
+    {
+        $manager = new GatewayManager();
+        $handled = false;
+
+        $manager->register(new class($handled) implements PaymentGateway {
+            private $handledRef;
+
+            public function __construct(& $handled)
+            {
+                $this->handledRef =& $handled;
+            }
+
+            public function key(): string
+            {
+                return 'mock';
+            }
+
+            public function displayName(): string
+            {
+                return 'Mock Gateway';
+            }
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+
+            public function createPayment(Invoice $invoice, array $options = []): Payment
+            {
+                throw new \LogicException('Not implemented in test double.');
+            }
+
+            public function handleWebhook(Request $request): void
+            {
+                $this->handledRef = true;
+            }
+        });
+
+        app()->forgetInstance(GatewayManager::class);
+        if (method_exists(app(), 'forgetResolvedInstance')) {
+            app()->forgetResolvedInstance(GatewayManager::class);
+        }
+        app()->instance(GatewayManager::class, $manager);
+
+        $response = $this->postJson('/webhook/payments/mock', ['event' => 'test']);
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true]);
+        $this->assertTrue($handled);
+    }
+}

--- a/tests/Feature/ServiceActionsTest.php
+++ b/tests/Feature/ServiceActionsTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Domain\Provisioning\Contracts\ProvisioningDriver;
+use App\Domain\Provisioning\ProvisioningManager;
+use App\Models\Client;
+use App\Models\Product;
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function createServiceForUser(User $user, array $attributes = []): Service
+    {
+        $client = Client::create(['user_id' => $user->id]);
+        $product = Product::create([
+            'name' => 'Compute Plan',
+            'slug' => 'compute-plan',
+            'description' => 'Test service',
+            'base_price' => 100000,
+            'currency' => 'IDR',
+            'options' => ['cpu' => 1],
+            'is_active' => true,
+        ]);
+        return Service::create(array_merge([
+            'client_id' => $client->id,
+            'product_id' => $product->id,
+            'status' => 'active',
+            'billing_cycle' => 'monthly',
+            'next_due_date' => now()->addMonth(),
+            'meta' => ['driver' => 'virtfusion', 'ip' => '192.0.2.10', 'password' => 'initial'],
+        ], $attributes));
+    }
+
+    protected function createVerifiedUser(array $attributes = []): User
+    {
+        return User::factory()->create(array_merge([
+            'email_verified_at' => now(),
+        ], $attributes));
+    }
+
+    public function test_owner_can_trigger_service_actions(): void
+    {
+        $user = $this->createVerifiedUser();
+        $service = $this->createServiceForUser($user);
+
+        $this->from('/services')->actingAs($user)->post('/services/'.$service->id.'/actions/reboot')
+            ->assertRedirect('/services')
+            ->assertSessionHas('status', 'Reboot command sent');
+
+        $this->from('/services')->actingAs($user)->post('/services/'.$service->id.'/actions/reset-password')
+            ->assertRedirect('/services')
+            ->assertSessionHas('status');
+
+        $service->refresh();
+        $this->assertNotEquals('initial', $service->meta['password']);
+    }
+
+    public function test_non_owner_cannot_invoke_actions(): void
+    {
+        $owner = $this->createVerifiedUser();
+        $service = $this->createServiceForUser($owner);
+        $other = $this->createVerifiedUser();
+
+        $this->actingAs($other)->post('/services/'.$service->id.'/actions/reboot')->assertStatus(403);
+    }
+
+    public function test_console_redirects_to_driver_console_url(): void
+    {
+        $user = $this->createVerifiedUser();
+        $service = $this->createServiceForUser($user);
+
+        $this->actingAs($user)->get('/services/'.$service->id.'/actions/console')
+            ->assertRedirect('about:blank');
+    }
+
+    public function test_service_action_failure_returns_generic_error(): void
+    {
+        $user = $this->createVerifiedUser();
+        $service = $this->createServiceForUser($user, ['meta' => ['driver' => 'failing']]);
+
+        app()->forgetInstance(ProvisioningManager::class);
+        if (method_exists(app(), 'forgetResolvedInstance')) {
+            app()->forgetResolvedInstance(ProvisioningManager::class);
+        }
+
+        $manager = new ProvisioningManager();
+        $manager->register(new class implements ProvisioningDriver {
+            public function key(): string { return 'failing'; }
+            public function displayName(): string { return 'Failing Driver'; }
+            public function create(Service $service, array $options = []): void {}
+            public function suspend(Service $service, array $options = []): void {}
+            public function unsuspend(Service $service, array $options = []): void {}
+            public function terminate(Service $service, array $options = []): void {}
+            public function reboot(Service $service): void { throw new \RuntimeException('driver exploded'); }
+            public function powerOn(Service $service): void {}
+            public function powerOff(Service $service): void {}
+            public function reinstall(Service $service, string $template): void {}
+            public function resize(Service $service, array $plan): void {}
+            public function snapshot(Service $service, array $options = []): void {}
+            public function resetPassword(Service $service): void {}
+            public function consoleUrl(Service $service): ?string { return 'about:blank'; }
+        });
+        app()->instance(ProvisioningManager::class, $manager);
+
+        $this->from('/services')->actingAs($user)->post('/services/'.$service->id.'/actions/reboot')
+            ->assertRedirect('/services')
+            ->assertSessionHas('error', 'Unable to complete the requested action. Please try again or contact support.');
+    }
+
+    public function test_console_failure_is_sanitized(): void
+    {
+        $user = $this->createVerifiedUser();
+        $service = $this->createServiceForUser($user, ['meta' => ['driver' => 'failing']]);
+
+        app()->forgetInstance(ProvisioningManager::class);
+        if (method_exists(app(), 'forgetResolvedInstance')) {
+            app()->forgetResolvedInstance(ProvisioningManager::class);
+        }
+
+        $manager = new ProvisioningManager();
+        $manager->register(new class implements ProvisioningDriver {
+            public function key(): string { return 'failing'; }
+            public function displayName(): string { return 'Failing Driver'; }
+            public function create(Service $service, array $options = []): void {}
+            public function suspend(Service $service, array $options = []): void {}
+            public function unsuspend(Service $service, array $options = []): void {}
+            public function terminate(Service $service, array $options = []): void {}
+            public function reboot(Service $service): void {}
+            public function powerOn(Service $service): void {}
+            public function powerOff(Service $service): void {}
+            public function reinstall(Service $service, string $template): void {}
+            public function resize(Service $service, array $plan): void {}
+            public function snapshot(Service $service, array $options = []): void {}
+            public function resetPassword(Service $service): void {}
+            public function consoleUrl(Service $service): ?string { throw new \RuntimeException('console offline'); }
+        });
+        app()->instance(ProvisioningManager::class, $manager);
+
+        $this->from('/services')->actingAs($user)->get('/services/'.$service->id.'/actions/console')
+            ->assertRedirect('/services')
+            ->assertSessionHas('error', 'Unable to open the console right now. Please try again or contact support.');
+    }
+}

--- a/tests/Feature/TicketWorkflowTest.php
+++ b/tests/Feature/TicketWorkflowTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Client;
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TicketWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_client_and_admin_ticket_flow(): void
+    {
+        $clientUser = User::factory()->create(['email_verified_at' => now()]);
+        $client = Client::create(['user_id' => $clientUser->id]);
+        $admin = User::factory()->create(['is_admin' => true, 'email_verified_at' => now()]);
+
+        $this->actingAs($clientUser)->post(route('tickets.store'), [
+            'subject' => 'Server down',
+            'department' => 'Support',
+            'priority' => 'high',
+            'message' => 'My server is down, please help.',
+        ])->assertRedirect();
+
+        $ticket = Ticket::first();
+        $this->assertNotNull($ticket);
+        $this->assertEquals('open', $ticket->status);
+        $this->assertCount(1, $ticket->replies);
+
+        $this->actingAs($admin)->post(route('admin.tickets.reply', $ticket), [
+            'message' => 'We are investigating.',
+        ])->assertRedirect();
+
+        $ticket->refresh();
+        $this->assertEquals('answered', $ticket->status);
+        $this->assertCount(2, $ticket->replies);
+        $this->assertEquals($admin->id, $ticket->last_reply_by);
+
+        $this->actingAs($clientUser)->post(route('tickets.reply', $ticket), [
+            'message' => 'Thank you for the update.',
+        ])->assertRedirect();
+
+        $ticket->refresh();
+        $this->assertEquals('open', $ticket->status);
+        $this->assertCount(3, $ticket->replies);
+
+        $this->actingAs($admin)->post(route('admin.tickets.status', $ticket), [
+            'status' => 'closed',
+        ])->assertRedirect();
+
+        $this->assertEquals('closed', $ticket->fresh()->status);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['app.installed' => true]);
+    }
 }


### PR DESCRIPTION
## Summary
- allow payment webhooks to bypass CSRF so external callbacks reach the application
- gate the manual payment gateway on explicit configuration, logging placeholders, and sanitize service action errors
- add regression coverage for webhook access, manual gateway visibility, and service action failures

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c998a728bc832e96f3902d349567bf